### PR TITLE
Fix some items acting as uninteractable watermelons

### DIFF
--- a/entities/entities/nut_item.lua
+++ b/entities/entities/nut_item.lua
@@ -9,9 +9,9 @@ ENT.RenderGroup = RENDERGROUP_BOTH
 
 if (SERVER) then
 	function ENT:Initialize()
-		self:SetModel("models/props_junk/watermelon01.mdl")
-		self:SetSolid(SOLID_VPHYSICS)
-		self:PhysicsInit(SOLID_VPHYSICS)
+		--self:SetModel("models/props_junk/watermelon01.mdl")
+		--self:SetSolid(SOLID_VPHYSICS)
+		--self:PhysicsInit(SOLID_VPHYSICS)
 		self:SetCollisionGroup(COLLISION_GROUP_WEAPON)
 		self.health = 50
 
@@ -51,14 +51,22 @@ if (SERVER) then
 				and "models/props_junk/cardboard_box004a.mdl"
 				or itemTable.worldModel
 		end
-
-		self:SetSkin(itemTable.skin or 0)
+		self:SetModel("models/props_junk/watermelon01.mdl")
 		self:SetModel(model)
+		self:SetSkin(itemTable.skin or 0)
+
+		if itemTable.groups then -- this has to be done after the model is set, hence why it looks a little messy
+			for k, v in pairs(itemTable.groups) do
+				if isstring(k) then k = self:FindBodygroupByName(k) end
+				self:SetBodygroup(k, v)
+			end
+		end
+
 		self:PhysicsInit(SOLID_VPHYSICS)
 		self:SetSolid(SOLID_VPHYSICS)
+		self:SetModel(model)
 		self:setNetVar("id", itemTable.uniqueID)
 		self.nutItemID = itemID
-
 		if (table.Count(itemTable.data) > 0) then
 			self:setNetVar("data", itemTable.data)
 		end

--- a/entities/entities/nut_item.lua
+++ b/entities/entities/nut_item.lua
@@ -51,8 +51,7 @@ if (SERVER) then
 				and "models/props_junk/cardboard_box004a.mdl"
 				or itemTable.worldModel
 		end
-		self:SetModel("models/props_junk/watermelon01.mdl")
-		self:SetModel(model)
+		self:SetModel(model or "models/props_junk/watermelon01.mdl")
 		self:SetSkin(itemTable.skin or 0)
 
 		if itemTable.groups then -- this has to be done after the model is set, hence why it looks a little messy
@@ -64,7 +63,6 @@ if (SERVER) then
 
 		self:PhysicsInit(SOLID_VPHYSICS)
 		self:SetSolid(SOLID_VPHYSICS)
-		self:SetModel(model)
 		self:setNetVar("id", itemTable.uniqueID)
 		self.nutItemID = itemID
 		if (table.Count(itemTable.data) > 0) then

--- a/gamemode/core/meta/item/sv_item.lua
+++ b/gamemode/core/meta/item/sv_item.lua
@@ -84,11 +84,11 @@ function ITEM:spawn(position, angles)
 
 		-- Spawn the actual item entity.
 		local entity = ents.Create("nut_item")
-		entity:Spawn()
 		entity:SetPos(position)
 		entity:SetAngles(angles or Angle(0, 0, 0))
 		-- Make the item represent this item.
 		entity:setItem(self.id)
+		entity:Spawn()
 		instance.entity = entity
 
 		if (IsValid(client)) then
@@ -284,4 +284,4 @@ function ITEM:interact(action, client, entity, data)
 	self.player = oldPlayer
 	self.entity = oldEntity
 	return true
-end
+end	

--- a/gamemode/core/sh_util.lua
+++ b/gamemode/core/sh_util.lua
@@ -37,8 +37,8 @@ function nut.util.includeDir(directory, fromLua, recursive)
 		baseDir = SCHEMA.folder.."/schema/"
 	else
 		baseDir = baseDir.."/gamemode/"
-	end 
-	
+	end
+
 	if recursive then
 		local function AddRecursive(folder)
 			local files, folders = file.Find(folder.."/*", "LUA")


### PR DESCRIPTION
The issue is that upon item entity spawn, the entity is always set to watermelon as a default. Then, in ENT:setItem, that code is run again, this time with the proper item model. Most of the time that's fine, however some models have funky physics that dont update, causing the model to stay with the watermelon physics, and not not traceable. Here we just set the correct model right away, avoiding that issue