### PR TITLE
Fixed an error when an object can be dropped

### DIFF
--- a/entities/weapons/nut_hands.lua
+++ b/entities/weapons/nut_hands.lua
@@ -611,8 +611,9 @@ end
 local down = Vector(0, 0, -1)
 function SWEP:allowEntityDrop()
 	local client = self:GetOwner()
+	local ent = self.carryHack
 
-	if (not IsValid(client)) or (not IsValid(self.carryHack)) then return false end
+	if (not IsValid(client)) or (not IsValid(ent)) then return false end
 
 	local ground = client:GetGroundEntity()
 	if ground and (ground:IsWorld() or IsValid(ground)) then return true end

--- a/entities/weapons/nut_hands.lua
+++ b/entities/weapons/nut_hands.lua
@@ -591,7 +591,7 @@ function SWEP:pickup(entity, trace)
 			local max_force = CARRY_FORCE_LIMIT
 
 			if (entity:GetClass() == "prop_ragdoll") then
-				self.dt.carried_rag = ent
+				self.dt.carried_rag = entity
 
 				bone = trace.PhysicsBone
 				max_force = 0


### PR DESCRIPTION
Error trace:

```
[ERROR] gamemodes/nutscript/entities/weapons/nut_hands.lua:620: attempt to index global 'ent' (a nil value)
  1. allowEntityDrop - gamemodes/nutscript/entities/weapons/nut_hands.lua:620
   2. drop - gamemodes/nutscript/entities/weapons/nut_hands.lua:223
    3. doPickup - gamemodes/nutscript/entities/weapons/nut_hands.lua:465
     4. unknown - gamemodes/nutscript/entities/weapons/nut_hands.lua:417
```

Introduced since https://github.com/NutScript/NutScript/commit/f1d717400b2e60303227253a7c7da16ca3523ffc#diff-7ab1cbc4dc8a07aef8065e4e182f8c2873e732fe9f419d626f517c52ec139f5e