### PR TITLE
global draw-over hook

### DIFF
--- a/gamemode/core/derma/cl_inventory.lua
+++ b/gamemode/core/derma/cl_inventory.lua
@@ -102,6 +102,8 @@ function PANEL:PaintOver(w, h)
 
 	if (itemTable and itemTable.paintOver) then
 		local w, h = self:GetSize()
+		
+		hook.Run("ItemPaintOver", self, itemTable, w, h)
 
 		itemTable.paintOver(self, itemTable, w, h)
 	end

--- a/gamemode/core/derma/cl_inventory.lua
+++ b/gamemode/core/derma/cl_inventory.lua
@@ -102,11 +102,11 @@ function PANEL:PaintOver(w, h)
 
 	if (itemTable and itemTable.paintOver) then
 		local w, h = self:GetSize()
-		
-		hook.Run("ItemPaintOver", self, itemTable, w, h)
 
 		itemTable.paintOver(self, itemTable, w, h)
 	end
+	
+	hook.Run("ItemPaintOver", self, itemTable, w, h)
 end
 
 function PANEL:PaintBehind(w, h)


### PR DESCRIPTION
Lets you draw over every type of item at once.