### PR TITLE
Fix the typing indicator when a player is acting

### DIFF
--- a/plugins/typing.lua
+++ b/plugins/typing.lua
@@ -31,13 +31,15 @@ if (CLIENT) then
 		data.filter = localPlayer
 
 		for k, v in ipairs(player.GetAll()) do
+			local isActing = v:getNetVar("actAng")
+
 			if (
 				v ~= localPlayer and
 				v:getNetVar("typing") and
-				v:GetMoveType() == MOVETYPE_WALK
+				(v:GetMoveType() == MOVETYPE_WALK or isActing)
 			) then
 				data.endpos = v:EyePos()
-				if (util.TraceLine(data).Entity ~= v) then continue end
+				if (util.TraceLine(data).Entity ~= v and not isActing) then continue end
 				local position = v:GetPos()
 				alpha = (1 - (ourPos:DistToSqr(position) / 65536)) * 255
 				if (alpha <= 0) then continue end


### PR DESCRIPTION
In the current state of the plugin, some acts performed by players do not display the typing indicator correctly.

This issue can be tested with a large majority of acts in citizens but also in Civil Protection units. Acting will cause the `GetMoveType` function to return **MOVETYPE_NONE** meaning that the player is immobile or dead. Also the `util.TraceLine` function with the current settings as well as those I have tested gives false negatives especially with /actsit.

This fix is intended to address this issue without having any undesirable effects on the way it worked before. It has been tested for days on a server with no unwanted effects, but I'm still listening if you have a better way to fix this problem.