### PR TITLE
give power to the canitembetransferred hook

### DIFF
--- a/plugins/gridinv/sv_access_rules.lua
+++ b/plugins/gridinv/sv_access_rules.lua
@@ -44,7 +44,7 @@ local function CanNotTransferBagIfNestedItemCanNotBe(inventory, action, context)
 
 	for _, item in pairs(bagInventory:getItems()) do
 		local canTransferItem, reason =
-			hook.Run("CanItemBeTransfered", item, bagInventory, bagInventory)
+			hook.Run("CanItemBeTransfered", item, bagInventory, bagInventory, context.client)
 		if (canTransferItem == false) then
 			return false, reason or "An item in the bag cannot be transfered"
 		end

--- a/plugins/gridinv/sv_transfer.lua
+++ b/plugins/gridinv/sv_transfer.lua
@@ -12,11 +12,9 @@ function PLUGIN:HandleItemTransferRequest(client, itemID, x, y, invID)
 		return
 	end
 	-- Make sure the item is permitted to move between the two inventories.
-	if (
-		hook.Run("CanItemBeTransfered", item, oldInventory, inventory) == false
-	) then
-		return
-	end
+	local status,reason = hook.Run("CanItemBeTransfered", item, oldInventory, inventory, client)
+	
+	if (status == false) then client:notify(reason or "You can't do that right now.") return end
 
 	local context = {
 		client = client,

--- a/plugins/vendor/sv_hooks.lua
+++ b/plugins/vendor/sv_hooks.lua
@@ -118,7 +118,7 @@ function PLUGIN:VendorTradeAttempt(
 				return
 			end
 
-			local canTransferItem, reason = hook.Run("CanItemBeTransfered", item, inventory, VENDOR_INVENTORY_MEASURE)
+			local canTransferItem, reason = hook.Run("CanItemBeTransfered", item, inventory, VENDOR_INVENTORY_MEASURE, client)
 			if (canTransferItem == false) then
 				client:notifyLocalized(reason or "vendorError")
 			


### PR DESCRIPTION
Fix it so that the canitembetransferred hook can actually notify the player of a reason, as well as allow it to see the transferring player.