### PR TITLE
Fix the non-updating of some parameters on commands

### DIFF
--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -9,7 +9,7 @@ end
 
 -- Returns a timestamp
 function nut.chat.timestamp(ooc)
-	return nut.config.get("chatShowTime") and (ooc and " " or "").."("..nut.date.getFormatted("%H:%M")..")"..(ooc and "" or " ") or ""
+	return nut.config.get("chatShowTime") and (ooc and " " or "") .. "(" .. nut.date.getFormatted("%H:%M") .. ")" .. (ooc and "" or " ") or ""
 end
 
 -- Registers a new chat type with the information provided.
@@ -58,7 +58,7 @@ function nut.chat.register(chatType, data)
 			end
 
 			local timestamp = nut.chat.timestamp(false)
-			local translated = L2(chatType.."Format", name, text)
+			local translated = L2(chatType .. "Format", name, text)
 
 			chat.AddText(timestamp, color, translated or string.format(data.format, name, text))
 		end
@@ -97,17 +97,17 @@ function nut.chat.parse(client, message, noSend)
 		if (type(v.prefix) == "table") then
 			for _, prefix in ipairs(v.prefix) do
 				-- Checking if the start of the message has the prefix.
-				if (message:sub(1, #prefix + (noSpaceAfter and 0 or 1)):lower() == prefix..(noSpaceAfter and "" or " "):lower()) then
+				if (message:sub(1, #prefix + (noSpaceAfter and 0 or 1)):lower() == prefix .. (noSpaceAfter and "" or " "):lower()) then
 					isChosen = true
-					chosenPrefix = prefix..(v.noSpaceAfter and "" or " ")
+					chosenPrefix = prefix .. (v.noSpaceAfter and "" or " ")
 
 					break
 				end
 			end
 		-- Otherwise the prefix itself is checked.
 		elseif (type(v.prefix) == "string") then
-			isChosen = message:sub(1, #v.prefix + (noSpaceAfter and 1 or 0)):lower() == v.prefix..(noSpaceAfter and "" or " "):lower()
-			chosenPrefix = v.prefix..(v.noSpaceAfter and "" or " ")
+			isChosen = message:sub(1, #v.prefix + (noSpaceAfter and 1 or 0)):lower() == v.prefix .. (noSpaceAfter and "" or " "):lower()
+			chosenPrefix = v.prefix .. (v.noSpaceAfter and "" or " ")
 		end
 
 		-- If the checks say we have the proper chat type, then the chat type is the chosen one!
@@ -219,7 +219,7 @@ do
 		-- Actions and such.
 		nut.chat.register("it", {
 			onChatAdd = function(speaker, text)
-				chat.AddText(nut.chat.timestamp(false), nut.config.get("chatColor"), "**"..text)
+				chat.AddText(nut.chat.timestamp(false), nut.config.get("chatColor"), "**" .. text)
 			end,
 			onCanHear = nut.config.get("chatRange", 280),
 			prefix = {"/it"},
@@ -259,7 +259,7 @@ do
 			onCanSay =  function(speaker, text)
 			if (!nut.config.get("allowGlobalOOC")) then
 				speaker:notifyLocalized("Global OOC is disabled on this server.")
-				return false		
+				return false
 			else
 				local delay = nut.config.get("oocDelay", 10)
 
@@ -309,7 +309,7 @@ do
 
 				icon = Material(hook.Run("GetPlayerIcon", speaker) or icon)
 
-				chat.AddText(icon, nut.chat.timestamp(true), Color(255, 50, 50), " [OOC] ", speaker, color_white, ": "..text)
+				chat.AddText(icon, nut.chat.timestamp(true), Color(255, 50, 50), " [OOC] ", speaker, color_white, ": " .. text)
 			end,
 			prefix = {"//", "/ooc"},
 			noSpaceAfter = true,
@@ -342,7 +342,7 @@ do
 				speaker.nutLastLOOC = CurTime()
 			end,
 			onChatAdd = function(speaker, text)
-				chat.AddText(nut.chat.timestamp(false), Color(255, 50, 50), "[LOOC] ", nut.config.get("chatColor"), speaker:Name()..": "..text)
+				chat.AddText(nut.chat.timestamp(false), Color(255, 50, 50), "[LOOC] ", nut.config.get("chatColor"), speaker:Name() .. ": " .. text)
 			end,
 			onCanHear = nut.config.get("chatRange", 280),
 			prefix = {".//", "[[", "/looc"},

--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -15,10 +15,21 @@ end
 -- Registers a new chat type with the information provided.
 function nut.chat.register(chatType, data)
 	if (not data.onCanHear) then
-		-- Have a substitute if the canHear property is not found.
-		data.onCanHear = function(speaker, listener)
-			-- The speaker will be heard by everyone.
-			return true
+		-- Let's see first if a dynamic radius has been set.
+		if (isfunction(data.radius)) then
+			-- If this is the case, then it gives the same situation where onCanHear property is a number.
+			-- But instead of entering a static number, the radius function will be called each time.
+			-- This can be useful if you want it to be linked to a variable that can be changed.
+			data.onCanHear = function(speaker, listener)
+				-- Squared distances will always perform better than standard distances.
+				return (speaker:GetPos() - listener:GetPos()):LengthSqr() <= (data.radius() ^ 2)
+			end
+		else
+			-- Have a substitute if the canHear and radius properties are not found.
+			data.onCanHear = function(speaker, listener)
+				-- The speaker will be heard by everyone.
+				return true
+			end
 		end
 	elseif (isnumber(data.onCanHear)) then
 		-- Use the value as a range and create a function to compare distances.

--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -213,14 +213,16 @@ do
 				-- Otherwise, use the normal chat color.
 				return nut.config.get("chatColor")
 			end,
-			onCanHear = nut.config.get("chatRange", 280)
+			radius = function()
+				return nut.config.get("chatRange", 280)
+			end
 		})
 
 		-- Actions and such.
 		nut.chat.register("me", {
 			format = "**%s %s",
 			onGetColor = nut.chat.classes.ic.onGetColor,
-			onCanHear = nut.config.get("chatRange", 280),
+			radius = function() return nut.config.get("chatRange", 280) end,
 			prefix = {"/me", "/action"},
 			font = "nutChatFontItalics",
 			filter = "actions",
@@ -232,7 +234,9 @@ do
 			onChatAdd = function(speaker, text)
 				chat.AddText(nut.chat.timestamp(false), nut.config.get("chatColor"), "**" .. text)
 			end,
-			onCanHear = nut.config.get("chatRange", 280),
+			radius = function()
+				return nut.config.get("chatRange", 280)
+			end,
 			prefix = {"/it"},
 			font = "nutChatFontItalics",
 			filter = "actions",
@@ -248,7 +252,9 @@ do
 				-- Make the whisper chat slightly darker than IC chat.
 				return Color(color.r - 35, color.g - 35, color.b - 35)
 			end,
-			onCanHear = nut.config.get("chatRange", 280) * 0.25,
+			radius = function()
+				return nut.config.get("chatRange", 280) * 0.25
+			end,
 			prefix = {"/w", "/whisper"}
 		})
 
@@ -261,7 +267,9 @@ do
 				-- Make the yell chat slightly brighter than IC chat.
 				return Color(color.r + 35, color.g + 35, color.b + 35)
 			end,
-			onCanHear = nut.config.get("chatRange", 280) * 2,
+			radius = function()
+				return nut.config.get("chatRange", 280) * 2
+			end,
 			prefix = {"/y", "/yell"}
 		})
 
@@ -347,7 +355,9 @@ do
 			onChatAdd = function(speaker, text)
 				chat.AddText(nut.chat.timestamp(false), Color(255, 50, 50), "[LOOC] ", nut.config.get("chatColor"), speaker:Name() .. ": " .. text)
 			end,
-			onCanHear = nut.config.get("chatRange", 280),
+			radius = function()
+				return nut.config.get("chatRange", 280)
+			end,
 			prefix = {".//", "[[", "/looc"},
 			noSpaceAfter = true,
 			filter = "ooc"
@@ -359,7 +369,7 @@ do
 			color = Color(155, 111, 176),
 			filter = "actions",
 			font = "nutChatFontItalics",
-			onCanHear = nut.config.get("chatRange", 280),
+			radius = function() return nut.config.get("chatRange", 280) end,
 			deadCanChat = true
 		})
 	end)
@@ -378,7 +388,6 @@ nut.chat.register("event", {
 	onCanSay =  function(speaker, text)
 		return speaker:IsAdmin()
 	end,
-	onCanHear = 1000000,
 	onChatAdd = function(speaker, text)
 		chat.AddText(nut.chat.timestamp(false), Color(255, 150, 0), text)
 	end,

--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -24,6 +24,14 @@ function nut.chat.register(chatType, data)
 				-- Squared distances will always perform better than standard distances.
 				return (speaker:GetPos() - listener:GetPos()):LengthSqr() <= (data.radius() ^ 2)
 			end
+		elseif (isnumber(data.radius)) then
+			-- To avoid confusion, the radius can be a static number.
+			-- In this case, we use the same method as the one used for the "onCanHear" property.
+			local range = data.radius ^ 2
+
+			data.onCanHear = function(speaker, listener)
+				return (speaker:GetPos() - listener:GetPos()):LengthSqr() <= range
+			end
 		else
 			-- Have a substitute if the canHear and radius properties are not found.
 			data.onCanHear = function(speaker, listener)

--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -323,8 +323,8 @@ do
 					local lastLOOC = CurTime() - speaker.nutLastLOOC
 
 					-- Use this method of checking time in case the oocDelay config changes (may not affect admins).
-					if (lastLOOC <= delay and (not speaker:IsAdmin() or speaker:IsAdmin() and nut.config.get("oocDelayAdmin", false))) then
-						speaker:notifyLocalized("oocDelay", delay - math.ceil(lastOOC))
+					if (lastLOOC <= delay and (not speaker:IsAdmin() or speaker:IsAdmin() and nut.config.get("loocDelayAdmin", false))) then
+						speaker:notifyLocalized("loocDelay", delay - math.ceil(lastLOOC))
 
 						return false
 					end


### PR DESCRIPTION
Following these modifications, here are the changes:
- The library code has been cleaned up to be more readable and cleaner.
- Improvements and small optimisations have been made along with the cleanup.
- The /looc command delay has been fixed as it was not working, sometimes creating Lua errors or just had no real restrictions.
- The introduction of a new property to allow dynamic retrieval of a value instead of having a static number (useful for some server parameters like `chatRadius`).
- Change the current commands to add the new parameter.

**~~Due to the number of changes, this is still being tested but so far no one has reported any issues.~~ Also, the compatibility of existing commands or commands from other servers is not broken.**