### PR TITLE
Add a hook to allow custom checks on commands

### DIFF
--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -56,10 +56,10 @@ function nut.command.add(command, data)
 
 		data._onRun = data.onRun -- for refactoring purpose.
 		data.onRun = function(client, arguments)
-			if (!onCheckAccess(client)) then
-				return "@noPerm"
-			else
+			if (hook.Run("CanPlayerUseCommand", client, command) or onCheckAccess(client)) then
 				return onRun(client, arguments)
+			else
+				return "@noPerm"
 			end
 		end
 	end


### PR DESCRIPTION
Thanks to it plugins' authors would be able to provide custom checks on commands for players that normally wouldn't be able to run them.

For example, a flag that gives access to charsetmodel or plytransfer for faction leaders.