### PR TITLE
Faction bodygroups and inv item icon models

### DIFF
--- a/gamemode/core/derma/cl_inventory.lua
+++ b/gamemode/core/derma/cl_inventory.lua
@@ -41,7 +41,7 @@ function PANEL:setItemType(itemTypeOrID)
 
 	self.nutToolTip = true
 	self.itemTable = item
-	self:SetModel(item.model, item.skin)
+	self:SetModel(item:getModel(), item:getSkin())
 	self:updateTooltip()
 
 	if (item.exRender) then
@@ -111,7 +111,7 @@ function PANEL:PaintOver(w, h)
 
 		itemTable.paintOver(self, itemTable, w, h)
 	end
-	
+
 	hook.Run("ItemPaintOver", self, itemTable, w, h)
 end
 

--- a/gamemode/core/libs/sh_character.lua
+++ b/gamemode/core/libs/sh_character.lua
@@ -265,10 +265,16 @@ do
 					newData.data.skin = model[2] or 0
 
 					local groups = {}
-					local i = 0
-					for value in model[3]:gmatch("%d") do
-						groups[i] = tonumber(value)
-						i = i + 1
+					if isstring(model[3]) then
+						local i = 0
+						for value in model[3]:gmatch("%d") do
+							groups[i] = tonumber(value)
+							i = i + 1
+						end
+					elseif istable(model[3]) then
+						for k, v in pairs(model[3]) do
+							groups[tonumber(k)] = tonumber(v)
+						end
 					end
 					newData.data.groups = groups
 				end
@@ -422,7 +428,7 @@ do
 
 	function playerMeta:Name()
 		local character = self.getChar(self)
-		
+
 		return character
 			and character.getName(character)
 			or self.steamName(self)

--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -54,6 +54,10 @@ function ITEM:getModel()
 	return self.model
 end
 
+function ITEM:getSkin()
+	return self.skin
+end
+
 function ITEM:getPrice()
 	local price = self.price
 

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -66,12 +66,12 @@ nut.command.add("flaggive", {
 		if (IsValid(target) and target:getChar()) then
 			local flags = arguments[2]
 
-			if (!flags) then
+			if (not flags) then
 				local available = ""
 
 				-- Aesthetics~~
 				for k in SortedPairs(nut.flag.list) do
-					if (!target:getChar():hasFlags(k)) then
+					if (not target:getChar():hasFlags(k)) then
 						available = available..k
 					end
 				end
@@ -97,7 +97,7 @@ nut.command.add("flagtake", {
 		if (IsValid(target) and target:getChar()) then
 			local flags = arguments[2]
 
-			if (!flags) then
+			if (not flags) then
 				return client:requestString("@flagTakeTitle", "@flagTakeDesc", function(text)
 					nut.command.run(client, "flagtake", {target:Name(), text})
 				end, target:getChar():getFlags())
@@ -114,7 +114,7 @@ nut.command.add("charsetmodel", {
 	adminOnly = true,
 	syntax = "<string name> <string model>",
 	onRun = function(client, arguments)
-		if (!arguments[2]) then
+		if (not arguments[2]) then
 			return L("invalidArg", client, 2)
 		end
 
@@ -179,7 +179,7 @@ nut.command.add("charsetname", {
 	onRun = function(client, arguments)
 		local target = nut.command.findPlayer(client, arguments[1])
 
-		if (IsValid(target) and !arguments[2]) then
+		if (IsValid(target) and not arguments[2]) then
 			return client:requestString("@chgName", "@chgNameDesc", function(text)
 				nut.command.run(client, "charsetname", {target:Name(), text})
 			end, target:Name())
@@ -201,7 +201,7 @@ nut.command.add("chargiveitem", {
 	adminOnly = true,
 	syntax = "<string name> <string item> <integer amount>",
 	onRun = function(client, arguments)
-		if (!arguments[2]) then
+		if (not arguments[2]) then
 			return L("invalidArg", client, 2)
 		end
 
@@ -211,7 +211,7 @@ nut.command.add("chargiveitem", {
 			local uniqueID = arguments[2]:lower()
 			local amount = tonumber(arguments[3])
 
-			if (!nut.item.list[uniqueID]) then
+			if (not nut.item.list[uniqueID]) then
 				for k, v in SortedPairs(nut.item.list) do
 					if (nut.util.stringMatches(v.name, uniqueID)) then
 						uniqueID = k
@@ -221,7 +221,7 @@ nut.command.add("chargiveitem", {
 				end
 			end
 
-			if (arguments[3] and arguments[3] ~= "") and (!amount) then
+			if (arguments[3] and arguments[3] ~= "") and (not amount) then
 				return L("invalidArg", client, 3)
 			end
 
@@ -312,14 +312,14 @@ nut.command.add("charunban", {
 
 				client.nutNextSearch = 0
 
-				if (!data.banned) then
+				if (not data.banned) then
 					return client:notifyLocalized("charNotBanned")
 				end
 
 				data.banned = nil
 
 				nut.db.updateTable({_data = data}, nil, nil, "_id = "..charID)
-				nut.util.notifyLocalized("charUnBan", nil, client:Name(), v:getName())
+				nut.util.notifyLocalized("charUnBan", nil, client:Name(), nut.char.loaded[charID]:getName())
 			end
 		end)
 	end
@@ -332,7 +332,7 @@ nut.command.add("givemoney", {
 		number = number or 0
 		local amount = math.floor(number)
 
-		if (!amount or !isnumber(amount) or amount <= 0) then
+		if (not amount or not isnumber(amount) or amount <= 0) then
 			return L("invalidArg", client, 1)
 		end
 
@@ -345,7 +345,7 @@ nut.command.add("givemoney", {
 		if (IsValid(target) and target:IsPlayer() and target:getChar()) then
 			amount = math.Round(amount)
 
-			if (!client:getChar():hasMoney(amount)) then
+			if (not client:getChar():hasMoney(amount)) then
 				return
 			end
 
@@ -366,7 +366,7 @@ nut.command.add("charsetmoney", {
 	onRun = function(client, arguments)
 		local amount = tonumber(arguments[2])
 
-		if (!amount or !isnumber(amount) or amount < 0) then
+		if (not amount or not isnumber(amount) or amount < 0) then
 			return "@invalidArg", 2
 		end
 
@@ -374,7 +374,7 @@ nut.command.add("charsetmoney", {
 
 		if (IsValid(target)) then
 			local char = target:getChar()
-			
+
 			if (char and amount) then
 				amount = math.Round(amount)
 				char:setMoney(amount)
@@ -389,13 +389,13 @@ nut.command.add("dropmoney", {
 	onRun = function(client, arguments)
 		local amount = tonumber(arguments[1])
 
-		if (!amount or !isnumber(amount) or amount < 1) then
+		if (not amount or not isnumber(amount) or amount < 1) then
 			return "@invalidArg", 1
 		end
 
 		amount = math.Round(amount)
-		
-		if (!client:getChar():hasMoney(amount)) then
+
+		if (not client:getChar():hasMoney(amount)) then
 			return
 		end
 
@@ -403,7 +403,7 @@ nut.command.add("dropmoney", {
 		local money = nut.currency.spawn(client:getItemDropPos(), amount)
 		money.client = client
 		money.charID = client:getChar():getID()
-		
+
 		client:doGesture(GESTURE_SLOT_ATTACK_AND_RELOAD, ACT_GMOD_GESTURE_ITEM_PLACE, true)
 	end
 })
@@ -432,11 +432,11 @@ nut.command.add("chargetup", {
 	onRun = function(client, arguments)
 		local entity = client.nutRagdoll
 
-		if (IsValid(entity) and entity.nutGrace and entity.nutGrace < CurTime() and entity:GetVelocity():Length2D() < 8 and !entity.nutWakingUp) then
+		if (IsValid(entity) and entity.nutGrace and entity.nutGrace < CurTime() and entity:GetVelocity():Length2D() < 8 and not entity.nutWakingUp) then
 			entity.nutWakingUp = true
 
 			client:setAction("@gettingUp", 5, function()
-				if (!IsValid(entity)) then
+				if (not IsValid(entity)) then
 					return
 				end
 
@@ -451,7 +451,7 @@ nut.command.add("plyunwhitelist", {
 	syntax = "<string name> <string faction>",
 	onRun = function(client, arguments)
 		local target = nut.command.findPlayer(client, arguments[1])
-		
+
 		if (IsValid(target)) then
 			local faction = nut.command.findFaction(client,table.concat(arguments, " ", 2))
 
@@ -471,7 +471,7 @@ nut.command.add("fallover", {
 	onRun = function(client, arguments)
 		local time = tonumber(arguments[1])
 
-		if (!isnumber(time)) then
+		if (not isnumber(time)) then
 			time = 5
 		end
 
@@ -481,7 +481,7 @@ nut.command.add("fallover", {
 			time = nil
 		end
 
-		if (!IsValid(client.nutRagdoll)) then
+		if (not IsValid(client.nutRagdoll)) then
 			client:setRagdolled(true, time)
 		end
 	end
@@ -495,7 +495,7 @@ nut.command.add("beclass", {
 
 		if (IsValid(client) and char) then
 			local num = isnumber(tonumber(class)) and tonumber(class) or -1
-			
+
 			if (nut.class.list[num]) then
 				local v = nut.class.list[num]
 
@@ -523,7 +523,7 @@ nut.command.add("beclass", {
 					end
 				end
 			end
-			
+
 			client:notifyLocalized("invalid", L("class", client))
 		else
 			client:notifyLocalized("illegalAccess")
@@ -536,7 +536,7 @@ nut.command.add("chardesc", {
 	onRun = function(client, arguments)
 		arguments = table.concat(arguments, " ")
 
-		if (!arguments:find("%S")) then
+		if (not arguments:find("%S")) then
 			return client:requestString("@chgDesc", "@chgDescDesc", function(text)
 				nut.command.run(client, "chardesc", {text})
 			end, client:getChar():getDesc())
@@ -584,7 +584,8 @@ nut.command.add("plytransfer", {
 				v, client:Name(), target:Name(), L(faction.name, v)
 			)
 		end
-	end
+	end,
+	alias = "charsetfaction"
 })
 
 -- Credit goes to SmithyStanley
@@ -593,7 +594,7 @@ nut.command.add("clearinv", {
 	syntax = "<string name>",
 	onRun = function (client, arguments)
 		local target = nut.command.findPlayer(client, arguments[1])
-		
+
 		if (IsValid(target) and target:getChar()) then
 			for k, v in pairs(target:getChar():getInv():getItems()) do
 				v:remove()

--- a/gamemode/core/sh_util.lua
+++ b/gamemode/core/sh_util.lua
@@ -37,8 +37,8 @@ function nut.util.includeDir(directory, fromLua, recursive)
 		baseDir = SCHEMA.folder.."/schema/"
 	else
 		baseDir = baseDir.."/gamemode/"
-	end 
-	
+	end
+
 	if recursive then
 		local function AddRecursive(folder)
 			local files, folders = file.Find(folder.."/*", "LUA")

--- a/plugins/attributes/derma/cl_attribute.lua
+++ b/plugins/attributes/derma/cl_attribute.lua
@@ -88,10 +88,8 @@ local PANEL = {}
 	end
 
 	function PANEL:Think()
-		if (self.pressing) then
-			if ((self.nextPress or 0) < CurTime()) then
-				self:doChange()
-			end
+		if self.pressing and ((self.nextPress or 0) < CurTime()) then
+			self:doChange()
 		end
 
 		self.deltaValue = math.Approach(self.deltaValue, self.value, FrameTime() * 15)
@@ -101,9 +99,9 @@ local PANEL = {}
 		if ((self.value == 0 and self.pressing == -1) or (self.value == self.max and self.pressing == 1)) then
 			return
 		end
-		
+
 		self.nextPress = CurTime() + 0.2
-		
+
 		if (self:onChanged(self.pressing) ~= false) then
 			self.value = math.Clamp(self.value + self.pressing, 0, self.max)
 		end
@@ -136,7 +134,7 @@ local PANEL = {}
 		self.sub:Remove()
 		self.add:Remove()
 	end
-	
+
 	function PANEL:Paint(w, h)
 		surface.SetDrawColor(0, 0, 0, 200)
 		surface.DrawRect(0, 0, w, h)

--- a/plugins/attributes/derma/cl_attributes_step.lua
+++ b/plugins/attributes/derma/cl_attributes_step.lua
@@ -54,12 +54,14 @@ end
 function PANEL:onPointChange(key, delta)
 	if (not key) then return 0 end
 	local attribs = self:getContext("attribs", {})
+	local startingMax = nut.attribs.list[key].startingMax or nil
 	local quantity = attribs[key] or 0
 	local newQuantity = quantity + delta
 	local newPointsLeft = self.left - delta
 	if (
 		newPointsLeft < 0 or newPointsLeft > self.total or
-		newQuantity < 0 or newQuantity > self.total
+		newQuantity < 0 or newQuantity > self.total or
+		(startingMax and startingMax < newQuantity)
 	) then
 		return quantity
 	end
@@ -100,7 +102,7 @@ function PANEL:Init()
 	self.quantity:Dock(FILL)
 	self.quantity:SetText("0")
 	self.quantity:SetContentAlignment(5)
-	
+
 	self.name = self:Add("DLabel")
 	self.name:SetFont("nutCharSubTitleFont")
 	self.name:SetContentAlignment(4)
@@ -111,8 +113,9 @@ end
 
 function PANEL:setAttribute(key, attribute)
 	self.key = key
+	local startingMax = nut.attribs.list[key].startingMax or nil
 	self.name:SetText(L(attribute.name))
-	self:SetToolTip(L(attribute.desc or "noDesc"))
+	self:SetTooltip(L(attribute.desc or "noDesc").. (startingMax and " Max: "..startingMax or ""))
 end
 
 function PANEL:delta(delta)

--- a/plugins/attributes/libs/sh_attribs.lua
+++ b/plugins/attributes/libs/sh_attribs.lua
@@ -2,7 +2,7 @@ nut.attribs = nut.attribs or {}
 nut.attribs.list = nut.attribs.list or {}
 
 function nut.attribs.loadFromDir(directory)
-	for k, v in ipairs(file.Find(directory.."/*.lua", "LUA")) do
+	for _, v in ipairs(file.Find(directory.."/*.lua", "LUA")) do
 		local niceName = v:sub(4, -5)
 
 		ATTRIBUTE = nut.attribs.list[niceName] or {}
@@ -39,10 +39,10 @@ do
 	if (SERVER) then
 		function charMeta:updateAttrib(key, value)
 			local attribute = nut.attribs.list[key]
+			local client = self:getPlayer()
 
 			if (attribute) then
 				local attrib = self:getAttribs()
-				local client = self:getPlayer()
 
 				attrib[key] = math.min((attrib[key] or 0) + value, attribute.maxValue or nut.config.get("maxAttribs", 30))
 
@@ -125,10 +125,10 @@ do
 		local boosts = self:getBoosts()[key]
 
 		if (boosts) then
-			for k, v in pairs(boosts) do
+			for _, v in pairs(boosts) do
 				att = att + v
 			end
-		end 
+		end
 
 		return att
 	end

--- a/plugins/attributes/plugins/strength/attributes/sh_str.lua
+++ b/plugins/attributes/plugins/strength/attributes/sh_str.lua
@@ -1,2 +1,4 @@
 ATTRIBUTE.name = "Strength"
 ATTRIBUTE.desc = "A measure of how strong you are."
+--ATTRIBUTE.startingMax = 10
+--ATTRIBUTE.noStartBonus = false

--- a/plugins/attributes/sh_plugin.lua
+++ b/plugins/attributes/sh_plugin.lua
@@ -26,9 +26,10 @@ nut.char.registerVar("attribs", {
 				local count = 0
 
 				for k, v in pairs(value) do
+					local max = nut.attribs.list[k] and nut.attribs.list[k].startingMax or nil
+					if max and max < v then return false, nut.attribs.list[k].name .. " too high" end
 					count = count + v
 				end
-
 				local points = hook.Run("GetStartAttribPoints", client, count)
 					or nut.config.get("maxAttribs", 30)
 				if (count > points) then


### PR DESCRIPTION
1. Allow bodygroups in faction models to use tables for better control over the forced bodygroups (since using a string has a limit of up to 9 bodygroups)

`FACTION.models = {
    {"models/kriegsyntax/rebel/army/army_trooper/playermodel_male_01.mdl", 0, {
        [0] = 13,
        [4] = 12,
        [6] = 2,
    }}
}`

2. Add onto #76 and make it used in the inv item icons, as well as add a getskin for items

3. Add startingMax points for attributes. (Do not allow an attrib to go above a number upon char creation)