### PR TITLE
GetMoneyModel hook

### DIFF
--- a/entities/entities/nut_money.lua
+++ b/entities/entities/nut_money.lua
@@ -8,7 +8,7 @@ ENT.Spawnable = false
 if (SERVER) then
 	function ENT:Initialize()
 		self:SetModel(
-			nut.config.get("moneyModel", "models/props_lab/box01a.mdl")
+			hook.Run("GetMoneyModel", self:getAmount()) or nut.config.get("moneyModel", "models/props_lab/box01a.mdl")
 		)
 		self:SetSolid(SOLID_VPHYSICS)
 		self:PhysicsInit(SOLID_VPHYSICS)


### PR DESCRIPTION
It's can be useful when different amount of money must have different models. It's can make the process of transferring money more realistic when, for example, a dollar looks like a dollar and five dollars looks like five dollars and so on.