### PR TITLE
ItemShouldTakeDamage hook added

### DIFF
--- a/entities/entities/nut_item.lua
+++ b/entities/entities/nut_item.lua
@@ -30,6 +30,8 @@ if (SERVER) then
 	end
 
 	function ENT:OnTakeDamage(dmginfo)
+		if (hook.Run("ItemShouldTakeDamage", self, dmginfo) == false) then return end
+			
 		local damage = dmginfo:GetDamage()
 		self:setHealth(self.health - damage)
 


### PR DESCRIPTION
I think it is essential for such hook to be since item entity have health and there no way to make all items or just a part really invulnerable for all or some types of damage without hacks like ent:setHealth(9999999999).
It's named like [PlayerShouldTakeDamage](https://wiki.facepunch.com/gmod/GM:PlayerShouldTakeDamage) and works similarly too.