### PR TITLE
Compression On Inventory Sync

### DIFF
--- a/gamemode/core/meta/inventory/cl_base_inventory.lua
+++ b/gamemode/core/meta/inventory/cl_base_inventory.lua
@@ -28,8 +28,7 @@ net.Receive("nutInventoryInit", function()
     local length = net.ReadUInt(32)
     local data2 = net.ReadData(length)
     local uncompressed_data = util.Decompress(data2)
-    print("=====HELLO====")
-    print(uncompressed_data)
+  
     local items = util.JSONToTable(uncompressed_data)
 
     local function readItem(I)


### PR DESCRIPTION
Long story short, someone on an NS server decided to have 0 weight items for listinv, and a person hit over 2000 items. While this doesn't fix the problem, it change slightly how the items are sent from the server to the client, meaning that its possible to have around 8000 items. 

AGAIN, not a good idea to have this many, but this essentially prevents this from happening as often. 