### PR TITLE
NutScript is full of Pedophiles and Scammers

### DIFF
--- a/nutscript.txt
+++ b/nutscript.txt
@@ -2,6 +2,6 @@
 {
 	"base"		"sandbox"
 	"title"		"NutScript 1.2"
-	"author"	"Chessnut, Black Tea and the NutScript Community"
+	"author"	"Chessnut, Black Tea and the NutScript Scammers"
 	"category"	"rp"
 }


### PR DESCRIPTION
The staff team is a bunch of pedophiles, as seen in the first screenshot, where he protects a staff from a CP server. They removed all proof involving the situation and decided to ban Barata out of spite. They are also backdoorers, as seen previously with Seamus and tend to hire people to lua steal in exchange for unbans, as seen in the second and third screenshots.

1 > https://media.discordapp.net/attachments/936359691871739945/1032076356093231114/unknown.png 2 > https://media.discordapp.net/attachments/936359691871739945/1032075596873879582/unknown.png 3 > https://media.discordapp.net/attachments/936359691871739945/1032075597188444250/unknown.png