### PR TITLE
Fixed Vendor Crash Exploit

### DIFF
--- a/plugins/vendor/sv_hooks.lua
+++ b/plugins/vendor/sv_hooks.lua
@@ -145,23 +145,23 @@ function PLUGIN:VendorTradeAttempt(
 
 		vendor:takeStock(itemType)
 
-		local position = client:getItemDropPos()
-		local result = character:getInv():add(itemType)
-			:next(function(item)
-				hook.Run("OnCharTradeVendor", client, vendor, item, isSellingToVendor)
-				client.vendorTransaction = nil
-			end)
-			:catch(function(err)
-				if (IsValid(client)) then
-					client:notifyLocalized("itemOnGround")
-				end
-				client.vendorTransaction = nil
-				return nut.item.spawn(itemType, position)
-			end)
-			:catch(function(err)
-				client:notifyLocalized(err)
-				client.vendorTransaction = nil
-			end)
+        local position = client:getItemDropPos()
+
+        local result = character:getInv():add(itemType):next(function(item)
+            hook.Run("OnCharTradeVendor", client, vendor, item, isSellingToVendor)
+            client.vendorTransaction = nil
+        end):catch(function(err)
+            if IsValid(client) then
+                client:notifyLocalized("Cannot add to inventory! Giving money back!")
+            end
+
+            client.vendorTransaction = nil
+
+            return character:giveMoney(price)
+        end):catch(function(err)
+            client:notifyLocalized(err)
+            client.vendorTransaction = nil
+        end)
 
 		nut.log.add(client, "vendorBuy", itemType, vendor:getNetVar("name"))
 	end


### PR DESCRIPTION
If the player doesn't have space on their inventory, the item would be dropped. 

This would increasingly hurt the server performance by overflowing the net channels, which can eventually lead to a crash.

This exploit has been here since 1.1 and it's time it gets fixed.

This fix consists in refunding the money and warning the player that there is no space for such item.