### PR TITLE
fixed pain sound hook called by all entities

### DIFF
--- a/plugins/playerinjuries/sv_hooks.lua
+++ b/plugins/playerinjuries/sv_hooks.lua
@@ -53,7 +53,7 @@ function PLUGIN:GetPlayerPainSound(client)
 end
 
 function PLUGIN:EntityTakeDamage(client, dmg)
-	if ((client.nutNextPain or 0) < CurTime() and client:Health() > 0) then
+	if (client:IsPlayer() and (client.nutNextPain or 0) < CurTime() and client:Health() > 0) then
 		local painSound = hook.Run("GetPlayerPainSound", client, dmg)
 			or PAIN_SOUNDS[math.random(#PAIN_SOUNDS)]
 		if (client:isFemale() and !painSound:find("female")) then


### PR DESCRIPTION
Recently changed hook used for player pain sounds, is called by all entities. Simply added a check to make sure the entity from EntityTakeDamage is a player.