### PR TITLE
SAM Commands

### DIFF
--- a/plugins/sam_commands.lua
+++ b/plugins/sam_commands.lua
@@ -4,9 +4,9 @@ PLUGIN.author = "Tov"
 
 if not (sam and sam.command) then return end -- Make sure SAM is installed
 
-for _, commandInfo in pairs(sam.command.get_commands()) do
+for _, commandInfo in ipairs(sam.command.get_commands()) do
     local customSyntax = ""
-    for _, argInfo in pairs(commandInfo.args) do
+    for _, argInfo in ipairs(commandInfo.args) do
         customSyntax = customSyntax == "" and "[" or customSyntax .. " ["
         customSyntax = customSyntax .. (argInfo.default and tostring(type(argInfo.default)) or "string") .. " "
         customSyntax = customSyntax .. argInfo.name .. "]"
@@ -21,5 +21,4 @@ for _, commandInfo in pairs(sam.command.get_commands()) do
             RunConsoleCommand("sam", commandInfo.name, unpack(arguments))
         end
     })
-
 end

--- a/plugins/sam_commands.lua
+++ b/plugins/sam_commands.lua
@@ -1,0 +1,25 @@
+PLUGIN.name = "Integrated SAM Commands"
+PLUGIN.desc = "Integrates SAM Commands into NutScript"
+PLUGIN.author = "Tov"
+
+if not (sam and sam.command) then return end -- Make sure SAM is installed
+
+for _, commandInfo in pairs(sam.command.get_commands()) do
+    local customSyntax = ""
+    for _, argInfo in pairs(commandInfo.args) do
+        customSyntax = customSyntax == "" and "[" or customSyntax .. " ["
+        customSyntax = customSyntax .. (argInfo.default and tostring(type(argInfo.default)) or "string") .. " "
+        customSyntax = customSyntax .. argInfo.name .. "]"
+    end
+
+    nut.command.add(commandInfo.name, {
+        adminOnly = commandInfo.default_rank == "admin",
+        superAdminOnly = commandInfo.default_rank == "superadmin",
+        syntax = customSyntax,
+        onRun = function(client, arguments)
+            --run the sam command
+            RunConsoleCommand("sam", commandInfo.name, unpack(arguments))
+        end
+    })
+
+end


### PR DESCRIPTION
Integrate SAM commands into NutScript.
This way, all commands added via SAM (that start with !) are accessible like NutScript commands (starting with /)

! commands still work, so any potential binds are not affected