### PR TITLE
Update sh_faction.lua

### DIFF
--- a/gamemode/core/libs/sh_faction.lua
+++ b/gamemode/core/libs/sh_faction.lua
@@ -80,6 +80,31 @@ function nut.faction.getIndex(uniqueID)
 	return nut.faction.teams[uniqueID] and nut.faction.teams[uniqueID].index
 end
 
+function createNutJob(index, name, color, default, models)
+	local FACTION = {}
+	
+	FACTION.index = index
+	FACTION.isDefault = default
+	FACTION.name = name
+	FACTION.desc = ""
+	FACTION.color = color
+	FACTION.models = models or CITIZEN_MODELS
+	FACTION.uniqueID = name
+	
+	for k, v in pairs(FACTION.models) do
+		if (isstring(v)) then
+			util.PrecacheModel(v)
+		elseif (istable(v)) then
+			util.PrecacheModel(v[1])
+		end
+	end
+	nut.faction.indices[FACTION.index] = FACTION
+	nut.faction.teams[name] = FACTION
+	team.SetUp(FACTION.index, FACTION.name, FACTION.color)
+	
+	return FACTION
+end
+
 if (CLIENT) then
 	function nut.faction.hasWhitelist(faction)
 		local data = nut.faction.indices[faction]

--- a/gamemode/core/libs/sv_database.lua
+++ b/gamemode/core/libs/sv_database.lua
@@ -364,7 +364,7 @@ CREATE TABLE IF NOT EXISTS `nut_characters` (
 	`_lastJoinTime` DATETIME NOT NULL,
 	`_data` VARCHAR(1024) DEFAULT NULL COLLATE 'utf8mb4_general_ci',
 	`_money` INT(10) UNSIGNED NULL DEFAULT '0',
-	`_faction` VARCHAR(24) DEFAULT NULL COLLATE 'utf8mb4_general_ci',
+	`_faction` VARCHAR(255) DEFAULT NULL COLLATE 'utf8mb4_general_ci',
 	PRIMARY KEY (`_id`)
 );
 CREATE TABLE IF NOT EXISTS `nut_inventories` (


### PR DESCRIPTION
TO COMPETE WITH DARKRP, THIS IS ESSENTIAL.
SIMPLE JOBS MADE QUICKLY & WHILE THE SERVER IS RUNNING

Adding factions in nutscript is aids.
I wrote a shitty script 5 years ago to fix that, now I've written a new one that should just be in nutscript.

Registering factions can be done easily OUTSIDE of nutscript in a shared file post gamemode load with the following code, you can also add them while the server is running, or even generate them automagically with other code.

FACTION_TATOOINE = createNutJob(0, "Tatooine Citizen", Color(255,0,0), true, {"model/path/here.mdl"})

FACTION_CORUSCANT = createNutJob(1, "Coruscant Citizen", Color(255,0,0), false, {"model/path/here.mdl"})

FACTION_NARSHADDAA = createNutJob(2, "Nar Shaddaa Citizen", Color(255,0,0), false, {"model/path/here.mdl"})