### PR TITLE
Update cl_scoreboard.lua

### DIFF
--- a/plugins/scoreboard/derma/cl_scoreboard.lua
+++ b/plugins/scoreboard/derma/cl_scoreboard.lua
@@ -108,6 +108,9 @@ local PANEL = {}
 
 			self.nextUpdate = CurTime() + 0.1
 		end
+		if input.IsKeyDown(KEY_Z) then
+			self:Init() -- Remake the scoreboard if Z is pressed, allows factions made AFTER player joins to appear by reinitializing.
+		end
 	end
 
 	function PANEL:addPlayer(client, parent)


### PR DESCRIPTION
Added functionality that if the panel is thinking and Z is pressed, the panel will reinitialized.

Why?
The scoreboard caches the factions list, if we inject a faction directly to the table AFTER the scoreboard is created then the faction will not appear, this Z button allows you to refresh that.