### PR TITLE
Fix incorrect vendor getting factions & classes access list updated on it

### DIFF
--- a/plugins/vendor/entities/entities/nut_vendor/init.lua
+++ b/plugins/vendor/entities/entities/nut_vendor/init.lua
@@ -325,21 +325,6 @@ function ENT:sync(client)
 			net.WriteInt(item[VENDOR_MODE] or -1, 8)
 		end
 	net.Send(client)
-
-	if (client:IsAdmin()) then
-		for factionID in pairs(self.factions) do
-			net.Start("nutVendorAllowFaction")
-				net.WriteUInt(factionID, 8)
-				net.WriteBool(true)
-			net.Send(client)
-		end
-		for classID in pairs(self.classes) do
-			net.Start("nutVendorAllowClass")
-				net.WriteUInt(classID, 8)
-				net.WriteBool(true)
-			net.Send(client)
-		end
-	end
 end
 
 function ENT:addReceiver(client, noSync)

--- a/plugins/vendor/sv_hooks.lua
+++ b/plugins/vendor/sv_hooks.lua
@@ -177,4 +177,20 @@ function PLUGIN:PlayerAccessVendor(client, vendor)
 	net.Start("nutVendorOpen")
 		net.WriteEntity(vendor)
 	net.Send(client)
+
+	-- Then, make sure admins have updated faction/class access data.
+	if (client:IsAdmin()) then
+		for factionID in pairs(vendor.factions) do
+			net.Start("nutVendorAllowFaction")
+				net.WriteUInt(factionID, 8)
+				net.WriteBool(true)
+			net.Send(client)
+		end
+		for classID in pairs(vendor.classes) do
+			net.Start("nutVendorAllowClass")
+				net.WriteUInt(classID, 8)
+				net.WriteBool(true)
+			net.Send(client)
+		end
+	end
 end


### PR DESCRIPTION
Currently when opening a vendor, the last vendor the player accessed has it's factions & classes lists set to instead of the new vendor, (the one the player is currently opening).

This PR will fix this issue by moving the calls `net.Start("nutVendorAllowFaction")` & `net.Start("nutVendorAllowClass")` to after sending the `net.Start("nutVendorOpen")` message, which the aforementioned functions rely on to work properly.
