### PR TITLE
Implementation of CAMI (Common Admin Mod Interface) into NS

### DIFF
--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -89,7 +89,7 @@ nut.config.add("oocLimit", 0, "Character limit per OOC message. 0 means no limit
 	category = "chat"
 })
 
-nut.config.add("oocDelayAdmin", false, "Whether or not OOC chat delay is enabled for admins.", nil, {
+nut.config.add("oocDelayAdmin", false, "Whether or not OOC chat delay is enabled for users with the permission \"NS.OOC.BypassDelay\".", nil, {
 	category = "chat"
 })
 
@@ -102,7 +102,7 @@ nut.config.add("loocDelay", 0, "The delay before a player can use LOOC chat agai
 	category = "chat"
 })
 
-nut.config.add("loocDelayAdmin", false, "Whether or not LOOC chat delay is enabled for admins.", nil, {
+nut.config.add("loocDelayAdmin", false, "Whether or not LOOC chat delay is enabled for users with the permission \"NS.OOC.BypassDelay\".", nil, {
 	category = "chat"
 })
 

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -610,12 +610,14 @@ function GM:CharacterPreSave(character)
 end
 
 function GM:OnServerLog(client, logType, ...)
-	for _, v in pairs(nut.util.getAdmins()) do
-
-		if (hook.Run("CanPlayerSeeLog", v, logType) ~= false) then
-			nut.log.send(v, nut.log.getString(client, logType, ...))
+	local vararg = {...}
+	CAMI.GetPlayersWithAccess("NS.Logs", function(allowedPlys)
+		for _, v in ipairs(allowedPlys) do
+			if (hook.Run("CanPlayerSeeLog", v, logType) ~= false) then
+				nut.log.send(v, nut.log.getString(client, logType, unpack(vararg)))
+			end
 		end
-	end
+	end)
 end
 
 -- this table is based on mdl's prop keyvalue data. FIX IT WILLOX!

--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -15,18 +15,8 @@ function nut.command.add(command, data)
 
 	-- Store the old onRun because we're able to change it.
 	if (!data.onCheckAccess) then
-		-- Check if the command is for basic admins only.
-		if (data.adminOnly) then
-			data.onCheckAccess = function(client)
-				return client:IsAdmin()
-			end
-		-- Or if it is only for super administrators.
-		elseif (data.superAdminOnly) then
-			data.onCheckAccess = function(client)
-				return client:IsSuperAdmin()
-			end
-		-- Or if we specify a usergroup allowed to use this.
-		elseif (data.group) then
+		-- cami is better than this rigmarole, but keep it for compat
+		if (data.group) then
 			-- The group property can be a table of usergroups.
 			if istable(data.group) then
 				data.onCheckAccess = function(client)
@@ -45,6 +35,19 @@ function nut.command.add(command, data)
 					return client:IsUserGroup(data.group)
 				end
 			end
+		end
+
+		local privilege = "NS.Commands." .. (data.privilege and data.privilege or command)
+
+		if (!CAMI.GetPrivilege(privilege)) then
+			CAMI.RegisterPrivilege({
+				Name = privilege,
+				MinAccess = data.adminOnly and "admin" or (data.superAdminOnly and "superadmin" or "user")
+			})
+		end
+
+		data.onCheckAccess = function(client)
+			return CAMI.PlayerHasAccess(client, privilege) == true
 		end
 	end
 

--- a/gamemode/core/libs/sh_log.lua
+++ b/gamemode/core/libs/sh_log.lua
@@ -21,6 +21,11 @@ nut.log.color = {
 }
 local consoleColor = Color(50, 200, 50)
 
+CAMI.RegisterPrivilege({
+	Name = "NS.Logs",
+	MinAccess = "admin"
+})
+
 if (SERVER) then
 	if (not nut.db) then
 		include("sv_database.lua")
@@ -101,7 +106,9 @@ if (SERVER) then
 	-- @realm server
 	function nut.log.addRaw(logString, shouldNotify, flag)		
 		if (shouldNotify) then
-			nut.log.send(nut.util.getAdmins(), logString, flag)
+			CAMI.GetPlayersWithAccess("NS.Logs", function(allowedPlys)
+				nut.log.send(allowedPlys, logString, flag)
+			end)
 		end
 
 		Msg("[LOG] ", logString.."\n")

--- a/gamemode/core/libs/thirdparty/sh_cami.lua
+++ b/gamemode/core/libs/thirdparty/sh_cami.lua
@@ -1,0 +1,362 @@
+--[[
+CAMI - Common Admin Mod Interface.
+Copyright 2020 CAMI Contributors
+
+Makes admin mods intercompatible and provides an abstract privilege interface
+for third party addons.
+
+Follows the specification on this page:
+https://github.com/glua/CAMI/blob/master/README.md
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+]]
+
+-- Version number in YearMonthDay format.
+local version = 20211019
+
+if CAMI and CAMI.Version >= version then return end
+
+CAMI = CAMI or {}
+CAMI.Version = version
+
+
+--- @class CAMI_USERGROUP
+--- defines the charactaristics of a usergroup
+--- @field Name string @The name of the usergroup
+--- @field Inherits string @The name of the usergroup this usergroup inherits from
+--- @field CAMI_Source string @The source specified by the admin mod which registered this usergroup (if any, converted to a string)
+
+--- @class CAMI_PRIVILEGE
+--- defines the charactaristics of a privilege
+--- @field Name string @The name of the privilege
+--- @field MinAccess "'user'" | "'admin'" | "'superadmin'" @Default group that should have this privilege
+--- @field Description string | nil @Optional text describing the purpose of the privilege
+local CAMI_PRIVILEGE = {}
+--- Optional function to check if a player has access to this privilege
+--- (and optionally execute it on another player)
+---
+--- ⚠ **Warning**: This function may not be called by all admin mods
+--- @param actor GPlayer @The player
+--- @param target GPlayer | nil @Optional - the target
+--- @return boolean @If they can or not
+--- @return string | nil @Optional reason
+function CAMI_PRIVILEGE:HasAccess(actor, target)
+end
+
+--- Contains the registered CAMI_USERGROUP usergroup structures.
+--- Indexed by usergroup name.
+--- @type CAMI_USERGROUP[]
+local usergroups = CAMI.GetUsergroups and CAMI.GetUsergroups() or {
+	user = {
+		Name = "user",
+		Inherits = "user",
+		CAMI_Source = "Garry's Mod",
+	},
+	admin = {
+		Name = "admin",
+		Inherits = "user",
+		CAMI_Source = "Garry's Mod",
+	},
+	superadmin = {
+		Name = "superadmin",
+		Inherits = "admin",
+		CAMI_Source = "Garry's Mod",
+	}
+}
+
+--- Contains the registered CAMI_PRIVILEGE privilege structures.
+--- Indexed by privilege name.
+--- @type CAMI_PRIVILEGE[]
+local privileges = CAMI.GetPrivileges and CAMI.GetPrivileges() or {}
+
+--- Registers a usergroup with CAMI.
+---
+--- Use the source parameter to make sure CAMI.RegisterUsergroup function and
+--- the CAMI.OnUsergroupRegistered hook don't cause an infinite loop
+--- @param usergroup CAMI_USERGROUP @The structure for the usergroup you want to register
+--- @param source any @Identifier for your own admin mod. Can be anything.
+--- @return CAMI_USERGROUP @The usergroup given as an argument
+function CAMI.RegisterUsergroup(usergroup, source)
+	if source then
+		usergroup.CAMI_Source = tostring(source)
+	end
+	usergroups[usergroup.Name] = usergroup
+
+	hook.Call("CAMI.OnUsergroupRegistered", nil, usergroup, source)
+	return usergroup
+end
+
+--- Unregisters a usergroup from CAMI. This will call a hook that will notify
+--- all other admin mods of the removal.
+---
+--- ⚠ **Warning**: Call only when the usergroup is to be permanently removed.
+---
+--- Use the source parameter to make sure CAMI.UnregisterUsergroup function and
+--- the CAMI.OnUsergroupUnregistered hook don't cause an infinite loop
+--- @param usergroupName string @The name of the usergroup.
+--- @param source any @Identifier for your own admin mod. Can be anything.
+--- @return boolean @Whether the unregistering succeeded.
+function CAMI.UnregisterUsergroup(usergroupName, source)
+	if not usergroups[usergroupName] then return false end
+
+	local usergroup = usergroups[usergroupName]
+	usergroups[usergroupName] = nil
+
+	hook.Call("CAMI.OnUsergroupUnregistered", nil, usergroup, source)
+
+	return true
+end
+
+--- Retrieves all registered usergroups.
+--- @return CAMI_USERGROUP[] @Usergroups indexed by their names.
+function CAMI.GetUsergroups()
+	return usergroups
+end
+
+--- Receives information about a usergroup.
+--- @param usergroupName string
+--- @return CAMI_USERGROUP | nil @Returns nil when the usergroup does not exist.
+function CAMI.GetUsergroup(usergroupName)
+	return usergroups[usergroupName]
+end
+
+--- Checks to see if potentialAncestor is an ancestor of usergroupName.
+--- All usergroups are ancestors of themselves.
+---
+--- Examples:
+--- * `user` is an ancestor of `admin` and also `superadmin`
+--- * `admin` is an ancestor of `superadmin`, but not `user`
+--- @param usergroupName string @The usergroup to query
+--- @param potentialAncestor string @The ancestor to query
+--- @return boolean @Whether usergroupName inherits potentialAncestor.
+function CAMI.UsergroupInherits(usergroupName, potentialAncestor)
+	repeat
+		if usergroupName == potentialAncestor then return true end
+
+		usergroupName = usergroups[usergroupName] and
+						 usergroups[usergroupName].Inherits or
+						 usergroupName
+	until not usergroups[usergroupName] or
+		  usergroups[usergroupName].Inherits == usergroupName
+
+	-- One can only be sure the usergroup inherits from user if the
+	-- usergroup isn't registered.
+	return usergroupName == potentialAncestor or potentialAncestor == "user"
+end
+
+--- Find the base group a usergroup inherits from.
+---
+--- This function traverses down the inheritence chain, so for example if you have
+--- `user` -> `group1` -> `group2`
+--- this function will return `user` if you pass it `group2`.
+---
+--- ℹ **NOTE**: All usergroups must eventually inherit either user, admin or superadmin.
+--- @param usergroupName string @The name of the usergroup
+--- @return "'user'" | "'admin'" | "'superadmin'" @The name of the root usergroup
+function CAMI.InheritanceRoot(usergroupName)
+	if not usergroups[usergroupName] then return end
+
+	local inherits = usergroups[usergroupName].Inherits
+	while inherits ~= usergroups[usergroupName].Inherits do
+		usergroupName = usergroups[usergroupName].Inherits
+	end
+
+	return usergroupName
+end
+
+--- Registers an addon privilege with CAMI.
+---
+--- ⚠ **Warning**: This should only be used by addons. Admin mods must *NOT*
+---  register their privileges using this function.
+--- @param privilege CAMI_PRIVILEGE
+--- @return CAMI_PRIVILEGE @The privilege given as argument.
+function CAMI.RegisterPrivilege(privilege)
+	privileges[privilege.Name] = privilege
+
+	hook.Call("CAMI.OnPrivilegeRegistered", nil, privilege)
+
+	return privilege
+end
+
+--- Unregisters a privilege from CAMI.
+--- This will call a hook that will notify any admin mods of the removal.
+---
+--- ⚠ **Warning**: Call only when the privilege is to be permanently removed.
+--- @param privilegeName string @The name of the privilege.
+--- @return boolean @Whether the unregistering succeeded.
+function CAMI.UnregisterPrivilege(privilegeName)
+	if not privileges[privilegeName] then return false end
+
+	local privilege = privileges[privilegeName]
+	privileges[privilegeName] = nil
+
+	hook.Call("CAMI.OnPrivilegeUnregistered", nil, privilege)
+
+	return true
+end
+
+--- Retrieves all registered privileges.
+--- @return CAMI_PRIVILEGE[] @All privileges indexed by their names.
+function CAMI.GetPrivileges()
+	return privileges
+end
+
+--- Receives information about a privilege.
+--- @param privilegeName string
+--- @return CAMI_PRIVILEGE | nil
+function CAMI.GetPrivilege(privilegeName)
+	return privileges[privilegeName]
+end
+
+-- Default access handler
+local defaultAccessHandler = {["CAMI.PlayerHasAccess"] =
+	function(_, actorPly, privilegeName, callback, targetPly, extraInfoTbl)
+		-- The server always has access in the fallback
+		if not IsValid(actorPly) then return callback(true, "Fallback.") end
+
+		local priv = privileges[privilegeName]
+
+		local fallback = extraInfoTbl and (
+			not extraInfoTbl.Fallback and actorPly:IsAdmin() or
+			extraInfoTbl.Fallback == "user" and true or
+			extraInfoTbl.Fallback == "admin" and actorPly:IsAdmin() or
+			extraInfoTbl.Fallback == "superadmin" and actorPly:IsSuperAdmin())
+
+
+		if not priv then return callback(fallback, "Fallback.") end
+
+		local hasAccess =
+			priv.MinAccess == "user" or
+			priv.MinAccess == "admin" and actorPly:IsAdmin() or
+			priv.MinAccess == "superadmin" and actorPly:IsSuperAdmin()
+
+		if hasAccess and priv.HasAccess then
+			hasAccess = priv:HasAccess(actorPly, targetPly)
+		end
+
+		callback(hasAccess, "Fallback.")
+	end,
+	["CAMI.SteamIDHasAccess"] =
+	function(_, _, _, callback)
+		callback(false, "No information available.")
+	end
+}
+
+--- @class CAMI_ACCESS_EXTRA_INFO
+--- @field Fallback "'user'" | "'admin'" | "'superadmin'" @Fallback status for if the privilege doesn't exist. Defaults to `admin`.
+--- @field IgnoreImmunity boolean @Ignore any immunity mechanisms an admin mod might have.
+--- @field CommandArguments table @Extra arguments that were given to the privilege command.
+
+--- Checks if a player has access to a privilege
+--- (and optionally can execute it on targetPly)
+---
+--- This function is designed to be asynchronous but will be invoked
+---  synchronously if no callback is passed.
+---
+--- ⚠ **Warning**: If the currently installed admin mod does not support
+---                 synchronous queries, this function will throw an error!
+--- @param actorPly GPlayer @The player to query
+--- @param privilegeName string @The privilege to query
+--- @param callback fun(hasAccess: boolean, reason: string|nil) @Callback to receive the answer, or nil for synchronous
+--- @param targetPly GPlayer | nil @Optional - target for if the privilege effects another player (eg kick/ban)
+--- @param extraInfoTbl CAMI_ACCESS_EXTRA_INFO | nil @Table of extra information for the admin mod
+--- @return boolean | nil @Synchronous only - if the player has the privilege
+--- @return string | nil @Synchronous only - optional reason from admin mod
+function CAMI.PlayerHasAccess(actorPly, privilegeName, callback, targetPly,
+extraInfoTbl)
+	local hasAccess, reason = nil, nil
+	local callback_ = callback or function(hA, r) hasAccess, reason = hA, r end
+
+	hook.Call("CAMI.PlayerHasAccess", defaultAccessHandler, actorPly,
+		privilegeName, callback_, targetPly, extraInfoTbl)
+
+	if callback ~= nil then return end
+
+	if hasAccess == nil then
+		local err = [[The function CAMI.PlayerHasAccess was used to find out
+		whether Player %s has privilege "%s", but an admin mod did not give an
+		immediate answer!]]
+		error(string.format(err,
+			actorPly:IsPlayer() and actorPly:Nick() or tostring(actorPly),
+			privilegeName))
+	end
+
+	return hasAccess, reason
+end
+
+--- Get all the players on the server with a certain privilege
+--- (and optionally who can execute it on targetPly)
+---
+--- ℹ **NOTE**: This is an asynchronous function!
+--- @param privilegeName string @The privilege to query
+--- @param callback fun(players: GPlayer[]) @Callback to receive the answer
+--- @param targetPly GPlayer | nil @Optional - target for if the privilege effects another player (eg kick/ban)
+--- @param extraInfoTbl CAMI_ACCESS_EXTRA_INFO | nil @Table of extra information for the admin mod
+function CAMI.GetPlayersWithAccess(privilegeName, callback, targetPly,
+extraInfoTbl)
+	local allowedPlys = {}
+	local allPlys = player.GetAll()
+	local countdown = #allPlys
+
+	local function onResult(ply, hasAccess, _)
+		countdown = countdown - 1
+
+		if hasAccess then table.insert(allowedPlys, ply) end
+		if countdown == 0 then callback(allowedPlys) end
+	end
+
+	for _, ply in ipairs(allPlys) do
+		CAMI.PlayerHasAccess(ply, privilegeName,
+			function(...) onResult(ply, ...) end,
+			targetPly, extraInfoTbl)
+	end
+end
+
+--- @class CAMI_STEAM_ACCESS_EXTRA_INFO
+--- @field IgnoreImmunity boolean @Ignore any immunity mechanisms an admin mod might have.
+--- @field CommandArguments table @Extra arguments that were given to the privilege command.
+
+--- Checks if a (potentially offline) SteamID has access to a privilege
+--- (and optionally if they can execute it on a target SteamID)
+---
+--- ℹ **NOTE**: This is an asynchronous function!
+--- @param actorSteam string | nil @The SteamID to query
+--- @param privilegeName string @The privilege to query
+--- @param callback fun(hasAccess: boolean, reason: string|nil) @Callback to receive  the answer
+--- @param targetSteam string | nil @Optional - target SteamID for if the privilege effects another player (eg kick/ban)
+--- @param extraInfoTbl CAMI_STEAM_ACCESS_EXTRA_INFO | nil @Table of extra information for the admin mod
+function CAMI.SteamIDHasAccess(actorSteam, privilegeName, callback,
+targetSteam, extraInfoTbl)
+	hook.Call("CAMI.SteamIDHasAccess", defaultAccessHandler, actorSteam,
+		privilegeName, callback, targetSteam, extraInfoTbl)
+end
+
+--- Signify that your admin mod has changed the usergroup of a player. This
+--- function communicates to other admin mods what it thinks the usergroup
+--- of a player should be.
+---
+--- Listen to the hook to receive the usergroup changes of other admin mods.
+--- @param ply GPlayer @The player for which the usergroup is changed
+--- @param old string @The previous usergroup of the player.
+--- @param new string @The new usergroup of the player.
+--- @param source any @Identifier for your own admin mod. Can be anything.
+function CAMI.SignalUserGroupChanged(ply, old, new, source)
+	hook.Call("CAMI.PlayerUsergroupChanged", nil, ply, old, new, source)
+end
+
+--- Signify that your admin mod has changed the usergroup of a disconnected
+--- player. This communicates to other admin mods what it thinks the usergroup
+--- of a player should be.
+---
+--- Listen to the hook to receive the usergroup changes of other admin mods.
+--- @param steamId string @The steam ID of the player for which the usergroup is changed
+--- @param old string @The previous usergroup of the player.
+--- @param new string @The new usergroup of the player.
+--- @param source any @Identifier for your own admin mod. Can be anything.
+function CAMI.SignalSteamIDUserGroupChanged(steamId, old, new, source)
+	hook.Call("CAMI.SteamIDUsergroupChanged", nil, steamId, old, new, source)
+end

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -57,6 +57,20 @@ nut.command.add("setvoicemail", {
 	end
 })
 
+nut.command.add("event", {
+	adminOnly = true,
+	syntax = "<string text>",
+	onRun = function(client, arguments)
+		local text = table.concat(arguments, " ")
+
+		if (text:find("%S")) then
+			nut.chat.send(client, "event", text)
+		else
+			return "@invalidArg", 1
+		end
+	end
+})
+
 nut.command.add("flaggive", {
 	adminOnly = true,
 	syntax = "<string name> [string flags]",

--- a/gamemode/core/sh_config.lua
+++ b/gamemode/core/sh_config.lua
@@ -1,6 +1,11 @@
 nut.config = nut.config or {}
 nut.config.stored = nut.config.stored or {}
 
+CAMI.RegisterPrivilege({
+	Name = "NS.Config",
+	MinAccess = "superadmin"
+})
+
 function nut.config.add(key, value, desc, callback, data, noNetworking, schemaOnly)
 	assert(isstring(key), "expected config key to be string, got " .. type(key))
 	local oldConfig = nut.config.stored[key]
@@ -130,7 +135,7 @@ if (SERVER) then
 	end
 
 	netstream.Hook("cfgSet", function(client, key, value)
-		if (client:IsSuperAdmin() and type(nut.config.stored[key].default) == type(value) and hook.Run("CanPlayerModifyConfig", client, key) ~= false) then
+		if (CAMI.PlayerHasAccess(client, "NS.Config") and type(nut.config.stored[key].default) == type(value) and hook.Run("CanPlayerModifyConfig", client, key) ~= false) then
 			nut.config.set(key, value)
 
 			if (istable(value)) then
@@ -190,7 +195,7 @@ if (CLIENT) then
 	local legacyConfigMenu = CreateClientConVar("nut_legacyconfig", "0", true, true)
 
 	hook.Add("CreateMenuButtons", "nutConfig", function(tabs)
-		if (not LocalPlayer():IsSuperAdmin() or hook.Run("CanPlayerUseConfig", LocalPlayer()) == false) then
+		if (not CAMI.PlayerHasAccess(LocalPlayer(), "NS.Config") or hook.Run("CanPlayerUseConfig", LocalPlayer()) == false) then
 			return
 		end
 

--- a/plugins/area/sh_plugin.lua
+++ b/plugins/area/sh_plugin.lua
@@ -6,6 +6,11 @@ PLUGIN.areaTable = PLUGIN.areaTable or {}
 nut.area = nut.area or {}
 ALWAYS_RAISED["nut_areahelper"] = true
 
+CAMI.RegisterPrivilege({
+	Name = "NS.ManageAreas",
+	MinAccess = "admin"
+})
+
 nut.config.add("areaFontSize", 26, "The size of the font of Area Display.",
 	function(oldValue, newValue)
 		if (CLIENT) then
@@ -148,8 +153,8 @@ if (SERVER) then
 	end
 
 	netstream.Hook("areaEdit", function(client, areaID, editData)
-		-- Only Admin can edit the area.
-		if (!client:IsAdmin()) then
+		-- Only players with the "NS.ManageAreas" permission can edit the area.
+		if (!CAMI.PlayerHasAccess(client, "NS.ManageAreas")) then
 			return false
 		end
 
@@ -165,8 +170,8 @@ if (SERVER) then
 	end)
 
 	netstream.Hook("areaTeleport", function(client, areaID, editData)
-		-- Only Admin can do this.
-		if (!client:IsAdmin()) then
+		-- Only players with the "NS.ManageAreas" permission can do this.
+		if (!CAMI.PlayerHasAccess(client, "NS.ManageAreas")) then
 			return false
 		end
 
@@ -180,8 +185,8 @@ if (SERVER) then
 	end)
 
 	netstream.Hook("areaAdd", function(client, name, vector1, vector2)
-		-- Only Admin can edit the area.
-		if (!client:IsAdmin() or !vector1 or !vector2 or !name) then
+		-- Only players with the "NS.ManageAreas" permission can edit the area.
+		if (!CAMI.PlayerHasAccess(client, "NS.ManageAreas") or !vector1 or !vector2 or !name) then
 			return false
 		end
 
@@ -189,8 +194,8 @@ if (SERVER) then
 	end)
 
 	netstream.Hook("areaRemove", function(client, areaID, editData)
-		-- Only Admin can edit the area.
-		if (!client:IsAdmin()) then
+		-- Only players with the "NS.ManageAreas" permission can edit the area.
+		if (!CAMI.PlayerHasAccess(client, "NS.ManageAreas")) then
 			return false
 		end
 

--- a/plugins/f1menu/derma/cl_helps.lua
+++ b/plugins/f1menu/derma/cl_helps.lua
@@ -103,31 +103,11 @@ hook.Add("BuildHelpMenu", "nutBasicHelp", function(tabs)
 		local body = ""
 
 		for k, v in SortedPairs(nut.command.list) do
-			local allowed = false
-
-			if (v.adminOnly and not LocalPlayer():IsAdmin()or v.superAdminOnly and not LocalPlayer():IsSuperAdmin()) then
+			if (not v.onCheckAccess(LocalPlayer())) then
 				continue
 			end
 
-			if (v.group) then
-				if (istable(v.group)) then
-					for _, v1 in pairs(v.group) do
-						if (LocalPlayer():IsUserGroup(v1)) then
-							allowed = true
-
-							break
-						end
-					end
-				elseif (LocalPlayer():IsUserGroup(v.group)) then
-					return true
-				end
-			else
-				allowed = true
-			end
-
-			if (allowed) then
-				body = body.."<h2>/"..k.."</h2><strong>Syntax:</strong> <em>"..v.syntax.."</em><br /><br />"
-			end
+			body = body.."<h2>/"..k.."</h2><strong>Syntax:</strong> <em>"..v.syntax.."</em><br /><br />"
 		end
 
 		return body

--- a/plugins/observer.lua
+++ b/plugins/observer.lua
@@ -2,6 +2,11 @@ PLUGIN.name = "Observer"
 PLUGIN.author = "Chessnut"
 PLUGIN.desc = "Adds on to the no-clip mode to prevent instrusion."
 
+CAMI.RegisterPrivilege({
+	Name = "NS.Observer",
+	MinAccess = "admin"
+})
+
 if (CLIENT) then
 	-- Create a setting to see if the player will teleport back after noclipping.
 	NUT_CVAR_OBSTPBACK = CreateClientConVar("nut_obstpback", 0, true, true)
@@ -13,7 +18,7 @@ if (CLIENT) then
 	function PLUGIN:HUDPaint()
 		client = LocalPlayer()
 
-		if (client:IsAdmin() and client:GetMoveType() == MOVETYPE_NOCLIP and !client:InVehicle() and NUT_CVAR_ADMINESP:GetBool()) then
+		if (CAMI.PlayerHasAccess(client, "NS.Observer") and client:GetMoveType() == MOVETYPE_NOCLIP and !client:InVehicle() and NUT_CVAR_ADMINESP:GetBool()) then
 			sx, sy = ScrW(), ScrH()
 
 			for k, v in ipairs(player.GetAll()) do
@@ -40,7 +45,7 @@ if (CLIENT) then
 	end
 
 	function PLUGIN:SetupQuickMenu(menu)
-		if (LocalPlayer():IsAdmin()) then
+		if (CAMI.PlayerHasAccess(LocalPlayer(), "NS.Observer")) then
 			menu:addCategory(self.name)
 
 			local buttonESP = menu:addCheck(L"toggleESP", function(panel, state)
@@ -74,7 +79,7 @@ if (CLIENT) then
 	function PLUGIN:ShouldDrawEntityInfo(entity)
 		if (IsValid(entity)) then
 			if (entity:IsPlayer() or IsValid(entity:getNetVar("player"))) then
-				if (entity.IsAdmin and entity:IsAdmin() and entity:GetMoveType() == MOVETYPE_NOCLIP) then
+				if (CAMI.PlayerHasAccess(entity, "NS.Observer") and entity:GetMoveType() == MOVETYPE_NOCLIP) then
 					return false
 				end
 			end
@@ -87,8 +92,8 @@ else
 	end
 
 	function PLUGIN:PlayerNoClip(client, state)
-		-- Observer mode is reserved for administrators.
-		if (client:IsAdmin()) then
+		-- Observer mode is reserved for players with the "NS.Observer" permission.
+		if (CAMI.PlayerHasAccess(client, "NS.Observer")) then
 			-- Check if they are entering noclip.
 			if (state) then
 				-- Store their old position and looking		 at angle.

--- a/plugins/pac/sh_permissions.lua
+++ b/plugins/pac/sh_permissions.lua
@@ -14,6 +14,10 @@ nut.config.add(
 	{category = PLUGIN.name}
 )
 
+CAMI.RegisterPrivilege({
+	Name = "NS.PAC",
+})
+
 -- Set up the flag corresponding to pacFlag config.
 local flag = nut.config.get("pacFlag")
 if (flag ~= "") then
@@ -44,6 +48,11 @@ function PLUGIN:isAllowedToUsePAC(client)
 		return true
 	end
 
+	if (CAMI.PlayerHasAccess(client, "NS.PAC")) then
+		return true
+	end
+
+	-- legacy method, kept for compat
 	local allowed = self:getAllowedUserGroups()
 	if (allowed.admin and client:IsAdmin()) then return true end
 	if (allowed.superadmin and client:IsSuperAdmin()) then return true end

--- a/plugins/propprotect.lua
+++ b/plugins/propprotect.lua
@@ -2,6 +2,11 @@ PLUGIN.name = "Basic Prop Protection"
 PLUGIN.author = "Chessnut"
 PLUGIN.desc = "Adds a simple prop protection system."
 
+CAMI.RegisterPrivilege({
+	Name = "NS.PropProtect.Bypass",
+	MinAccess = "admin"
+})
+
 local PROP_BLACKLIST = {
 	["models/props_combine/combinetrain02b.mdl"] = true,
 	["models/props_combine/combinetrain02a.mdl"] = true,
@@ -72,19 +77,19 @@ if (SERVER) then
 			return false
 		end
 
-		if (!client:IsAdmin() and PROP_BLACKLIST[model:lower()]) then
+		if (!CAMI.PlayerHasAccess(client, "NS.PropProtect.Bypass") and PROP_BLACKLIST[model:lower()]) then
 			return false
 		end
 	end
 
 	function PLUGIN:PhysgunPickup(client, entity)
-		if (entity:GetCreator() == client) then
+		if (entity:GetCreator() == client or CAMI.PlayerHasAccess(client, "NS.PropProtect.Bypass")) then
 			return true
 		end
 	end
 
 	function PLUGIN:CanProperty(client, property, entity)
-		if (entity:GetCreator() == client and (property == "remover" or property == "collision")) then
+		if ((entity:GetCreator() == client and (property == "remover" or property == "collision")) or CAMI.PlayerHasAccess(client, "NS.PropProtect.Bypass")) then
 			return true
 		end
 	end
@@ -92,7 +97,7 @@ if (SERVER) then
 	function PLUGIN:CanTool(client, trace, tool)
 		local entity = trace.Entity
 
-		if (IsValid(entity) and entity:GetCreator() == client) then
+		if (IsValid(entity) and (entity:GetCreator() == client or CAMI.PlayerHasAccess(client, "NS.PropProtect.Bypass"))) then
 			return true
 		end
 	end

--- a/plugins/vendor/derma/cl_vendor.lua
+++ b/plugins/vendor/derma/cl_vendor.lua
@@ -34,7 +34,7 @@ function PANEL:Init()
 	self.leave:SetPaintBackground(false)
 	self.leave.x = ScrW() * 0.5 - (self.leave:GetWide() * 0.5)
 
-	if (LocalPlayer():IsAdmin()) then
+	if (CAMI.PlayerHasAccess(LocalPlayer(), "NS.ManageVendors")) then
 		self.editor = self.buttons:Add("DButton")
 		self.editor:SetFont("nutVendorButtonFont")
 		self.editor:SetText(L("editor"):upper())

--- a/plugins/vendor/sh_plugin.lua
+++ b/plugins/vendor/sh_plugin.lua
@@ -2,6 +2,11 @@ PLUGIN.name = "Vendors"
 PLUGIN.author = "Chessnut"
 PLUGIN.desc = "Adds NPC vendors that can sell things."
 
+CAMI.RegisterPrivilege({
+	Name = "NS.ManageVendors",
+	MinAccess = "admin"
+})
+
 if (SERVER) then
 	AddCSLuaFile("cl_editor.lua")
 end

--- a/plugins/vendor/sv_hooks.lua
+++ b/plugins/vendor/sv_hooks.lua
@@ -1,6 +1,6 @@
 -- Determines whether or not a player can use a vendor.
 function PLUGIN:CanPlayerAccessVendor(client, vendor)
-	if (client:IsAdmin()) then
+	if (CAMI.PlayerHasAccess(client, "NS.ManageVendors")) then
 		return true
 	end
 

--- a/plugins/vendor/sv_networking.lua
+++ b/plugins/vendor/sv_networking.lua
@@ -24,7 +24,7 @@ end)
 net.Receive("nutVendorEdit", function(_, client)
 	local key = net.ReadString()
 
-	if (not client:IsAdmin()) then return end
+	if (not CAMI.PlayerHasAccess(client, "NS.ManageVendors")) then return end
 
 	local vendor = client.nutVendor
 	if (not IsValid(vendor) or not EDITOR[key]) then return end


### PR DESCRIPTION
There are some missing things, (on purpose or not /shrug) SAM integration doesn't have any CAMI privileges, the default `PlayerGiveSWEP`, `PlayerSpawnEffect`, `PlayerSpawnSENT`, `PlayerSpawnNPC`, `PlayerSpawnSWEP` don't use CAMI the `doorsettitle` command has an IsAdmin call that I'm not sure of, the scoreboard uses an IsAdmin call (could have a permission). And the vendor `sync` still uses IsAdmin as we should realistically wait for #162 to be merged then fix it use CAMI.

I also haven't completely looked over everything to make sure it all functions as expected, hence draft status.