### PR TITLE
Update Credits page UI

### DIFF
--- a/.github/workflows/credits-cache.yml
+++ b/.github/workflows/credits-cache.yml
@@ -1,0 +1,119 @@
+
+name: Cache contributor data
+
+on:
+  push:
+  workflow_dispatch:
+
+env:
+  CACHE_BRANCH: credits-cache
+  BLOCKLIST: |
+    [
+      8109941,
+      33399712,
+      96260021,
+      41455508,
+      41898282
+    ]
+
+jobs:
+  build-cache:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4.1.5
+      with:
+        ref: ${{ env.CACHE_BRANCH }}
+        fetch-depth: 0
+    - uses: actions/github-script@v7.0.1
+      id: getContributors
+      with:
+        script: |
+          const { data: contributors } = await github.rest.repos.listContributors({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            per_page: 50,
+          })
+          return contributors
+    - uses: actions/github-script@v7.0.1
+      id: getNames
+      env:
+          getContributors: ${{ steps.getContributors.outputs.result }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+            const contributors = JSON.parse(process.env.getContributors)
+            var query = "query{search(first:50query:\""
+            for (i = 0; i < contributors.length; i++) {
+              const contributor = contributors[i]
+              if (contributor.login) {
+                query += "user:" + contributor.login + " "
+              }
+            }
+            query += "\"type:USER){nodes{... on User {name id}}}}"
+            const { search: result } = await github.graphql(query)
+            return result.nodes
+    - uses: actions/github-script@v7.0.1
+      id: buildData
+      env:
+          getContributors: ${{ steps.getContributors.outputs.result }}
+          getNames: ${{ steps.getNames.outputs.result }}
+      with:
+        script: |
+            const fs = require("fs")
+            const util = require("util")
+            const writeFileAsync = util.promisify(fs.writeFile)
+
+            const blocklist = JSON.parse(process.env.BLOCKLIST)
+            const contributors = JSON.parse(process.env.getContributors)
+            const names = JSON.parse(process.env.getNames)
+
+            var blockedUsers = {}
+            for (i = 0; i < blocklist.length; i++) {
+              blockedUsers[blocklist[i]] = true
+            }
+
+            var namedUsers = {}
+            for (i = 0; i < names.length; i++) {
+              namedUsers[names[i].id] = names[i].name
+            }
+
+            var contributorMetadata = []
+            for (i = 0; i < contributors.length; i++) {
+              const contributor = contributors[i]
+
+              if (!blockedUsers[contributor.id]) {
+                contributorMetadata.push({
+                  id: contributor.id,
+                  name: namedUsers[contributor.node_id] ? namedUsers[contributor.node_id] : contributor.login,
+                  login: contributor.login,
+                })
+
+                const avatarData = await fetch("https://avatars.githubusercontent.com/u/" + contributor.id, {
+                  method: "GET",
+                  headers: {
+                    'Accept': 'image/avif,image/webp,*/*'
+                  },
+                })
+                const blob = await avatarData.blob()
+                const arrayBuffer = await blob.arrayBuffer();
+                const buffer = Buffer.from(arrayBuffer);
+                await writeFileAsync("./" + contributor.id, buffer)
+              }
+            }
+
+            await writeFileAsync("./contributors.json", JSON.stringify(contributorMetadata))
+    - name: Commit files
+      run: |
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add .
+        git commit --allow-empty -a -m "Rebuild credits-cache"
+    - name: Push changes
+      uses: ad-m/github-push-action@v0.8.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ env.CACHE_BRANCH }}
+        force: true

--- a/plugins/f1menu/derma/cl_helps.lua
+++ b/plugins/f1menu/derma/cl_helps.lua
@@ -47,37 +47,25 @@
 			tree:DockMargin(0, 0, 15, 0)
 			tree.OnNodeSelected = function(this, node)
 				if (node.onGetHTML) then
+					for k, panel in ipairs(helpPanel:GetChildren()) do
+						if (panel != html) then
+							panel:Remove()
+						end
+					end
+
 					local source = node:onGetHTML()
-					if IsValid(helpPanel) then
-						helpPanel:Remove()
-					end
-					if nut.gui.creditsPanel then
-						nut.gui.creditsPanel:Remove()
-					end
-
-					helpPanel = panel:Add("DListView")
-					helpPanel:Dock(FILL)
-					helpPanel.Paint = function()
-					end
-					helpPanel:InvalidateLayout(true)
-
-					html = helpPanel:Add("DHTML")
-					html:Dock(FILL)
-					html:SetHTML(header..HELP_DEFAULT)
 
 					if (source and source:sub(1, 4) == "http") then
 						html:OpenURL(source)
 					else
-						html:SetHTML(header..node:onGetHTML().."</body></html>")
+						html:SetHTML(header..source.."</body></html>")
 					end
 				end
 			end
 
 			if not IsValid(helpPanel) then
-				helpPanel = panel:Add("DListView")
+				helpPanel = panel:Add("Panel")
 				helpPanel:Dock(FILL)
-				helpPanel.Paint = function()
-				end
 
 				html = helpPanel:Add("DHTML")
 				html:Dock(FILL)

--- a/plugins/nscredits.lua
+++ b/plugins/nscredits.lua
@@ -77,6 +77,8 @@ function PANEL:Init()
         http.Fetch("https://api.github.com/repos/NutScript/NutScript/contributors?per_page=100",
             function(body, length, headers, code)
                 if (#PLUGIN.contributorData > 0) then
+                    self:RebuildContributors()
+
                     return
                 end
 
@@ -86,10 +88,6 @@ function PANEL:Init()
                     if (not PLUGIN.excludeList[v.login]) then
                         table.insert(PLUGIN.contributorData, {url = v.html_url, avatar_url = v.avatar_url, name = v.login})
                     end
-                end
-
-                if (self.RebuildContributors) then
-                    self:RebuildContributors()
                 end
             end, function(message) end, {})
     else

--- a/plugins/nscredits.lua
+++ b/plugins/nscredits.lua
@@ -1,172 +1,40 @@
+
+local PLUGIN = PLUGIN
+
 PLUGIN.name = "Credits Tab"
 PLUGIN.desc = "A tab where players can see who made the framework/schema"
 PLUGIN.author = "NS Team"
 
 if SERVER then return end
 
-local ScrW, ScrH = ScrW(), ScrH()
-local logoMat = Material("nutscript/logo.png")
-local logoGlowMat = Material("nutscript/logo_glow.png")
-local textureID = surface.GetTextureID("models/effects/portalfunnel_sheet")
-local sin = math.sin
+PLUGIN.excludeList = {
+    ["github_username_here"] = true
+}
+PLUGIN.contributorData = PLUGIN.contributorData or {}
+
+local logoMat = nut.util.getMaterial("nutscript/logo.png")
+
 surface.CreateFont("nutSmallCredits", {
-    font = "Roboto",
+    font = "Roboto Th",
     size = 20,
     weight = 400
 })
 
 surface.CreateFont("nutBigCredits", {
-    font = "Roboto",
+    font = "Roboto Th",
     size = 32,
     weight = 600
 })
 
-local colorCreator, colorLDev, colorDev = Color(255, 0, 0), Color(138,43,226), Color(34,139,34)
-
-local authorCredits = {
-    {desc = "Creator", steamid = "76561198030127257", color = colorCreator}, -- Chessnut
-    {desc = "Co-Creator", steamid = "76561197999893894", color = colorCreator}, -- Black Tea
-    {desc = "Lead Developer", steamid = "76561198060659964", color = colorLDev}, -- Zoephix
-    {desc = "Lead Developer", steamid = "76561198070441753", color = colorLDev}, -- TovarischPootis
-    {desc = "Developer", steamid = "76561198036551982", color = colorDev}, -- Seamus
-    {desc = "Developer", steamid = "76561198251000796", color = colorDev}, -- Dobytchick
-    {desc = "Developer", steamid = "76561198031437460", color = colorDev}, -- Milk
-}
-
-do
-    for _, v in ipairs(authorCredits) do
-        steamworks.RequestPlayerInfo(v.steamid, function(steamName)
-            v.name = steamName or "Loading..."
-        end)
-    end
-end
-
-local contributors = {desc = "View All Contributors", url = "https://github.com/NutScript/NutScript/graphs/contributors"}
-local discord = {desc = "Join the NutScript Community Discord", url = "https://discord.gg/ySZY8TY"}
-
 local PANEL = {}
 
-function PANEL:Init()
-
-    self.avatarImage = self:Add("AvatarImage")
-    self.avatarImage:Dock(LEFT)
-    self.avatarImage:SetSize(64,64)
-
-    self.name = self:Add("DLabel")
-    self.name:SetFont("nutBigCredits")
-    self.name:SetText("Loading...")
-
-    self.desc = self:Add("DLabel")
-    self.desc:SetFont("nutSmallCredits")
-end
-
-function PANEL:setAvatarImage(id)
-    if not self.avatarImage then return end
-    self.avatarImage:SetSteamID(id, 64)
-    self.avatarImage.OnCursorEntered = function()
-        surface.PlaySound("garrysmod/ui_return.wav")
-    end
-
-    self.avatarImage.OnMousePressed = function()
-        surface.PlaySound("buttons/button14.wav")
-        gui.OpenURL("http://steamcommunity.com/profiles/"..id)
-    end
-end
-
-function PANEL:setName(name, color)
-    if not IsValid(self.name) then return end
-    self.name:SetText(name)
-    if color then
-        self.name:SetTextColor(color)
-    end
-    self.name:SizeToContents()
-    self.name:Dock(TOP)
-    self.name:DockMargin(ScrW*0.01, 0,0,0)
-end
-
-function PANEL:setDesc(desc)
-    if not self.desc then return end
-    self.desc:SetText(desc)
-    self.desc:SizeToContents()
-    self.desc:Dock(TOP)
-    self.desc:DockMargin(ScrW*0.01, 0,0,0)
-end
-
 function PANEL:Paint(w, h)
-    surface.SetTexture(textureID)
-    surface.DrawTexturedRect(0, 0, w, h)
-end
-vgui.Register("CreditsNamePanel", PANEL, "DPanel")
-
-PANEL = {}
-
-function PANEL:Init()
-    self.contButton = self:Add("DButton")
-    self.contButton:SetFont("nutBigCredits")
-    self.contButton:SetText(contributors.desc)
-    self.contButton.DoClick = function()
-        surface.PlaySound("buttons/button14.wav")
-		gui.OpenURL(contributors.url)
-    end
-    self.contButton.Paint = function() end
-    self.contButton:Dock(TOP)
-
-    self.discordButton = self:Add("DButton")
-    self.discordButton:SetFont("nutBigCredits")
-    self.discordButton:SetText(discord.desc)
-    self.discordButton.DoClick = function()
-        surface.PlaySound("buttons/button14.wav")
-		gui.OpenURL(discord.url)
-    end
-    self.discordButton.Paint = function() end
-    self.discordButton:Dock(TOP)
-    self:SizeToChildren(true, true)
-end
-
-function PANEL:Paint()
-end
-
-vgui.Register("CreditsContribPanel", PANEL, "DPanel")
-
-PANEL = {}
-
-function PANEL:Init()
-
-end
-
-function PANEL:setPerson(data, left)
-    local id = left and "creditleft" or "creditright"
-    self[id] = self:Add("CreditsNamePanel")
-    self[id]:setAvatarImage(data.steamid)
-    self[id]:setName(data.name, data.color)
-    self[id]:setDesc(data.desc)
-    self[id]:Dock(left and LEFT or RIGHT)
-    self[id]:InvalidateLayout(true)
-    self[id]:SizeToChildren(false, true)
-    self:InvalidateLayout(true)
-    self[id]:SetWide((self:GetWide()/2)+32)
-end
-
-function PANEL:Paint()
-end
-
-vgui.Register("CreditsCreditsList", PANEL, "DPanel")
-
-PANEL = {}
-
-function PANEL:Init()
-end
-
-function PANEL:Paint(w,h)
-    surface.SetMaterial(logoGlowMat)
-    surface.SetDrawColor(255, 255, 255, 64*sin(CurTime())+191)
-    surface.DrawTexturedRect((w/2)-128,(h/2)-128,256,256)
     surface.SetMaterial(logoMat)
     surface.SetDrawColor(255, 255, 255, 255)
-    surface.DrawTexturedRect((w/2)-128,(h/2)-128,256,256)
+    surface.DrawTexturedRect(w * 0.5 - 128, h * 0.5 - 128, 256, 256)
 end
 
-vgui.Register("CreditsLogo", PANEL, "DPanel")
+vgui.Register("CreditsLogo", PANEL, "Panel")
 
 PANEL = {}
 
@@ -176,54 +44,163 @@ function PANEL:Init()
     end
     nut.gui.creditsPanel = self
 
-    self:SetSize(ScrW*0.3, ScrH*0.7)
-
     self.logo = self:Add("CreditsLogo")
-    self.logo:SetSize(ScrW*0.4, ScrW*0.1)
+    self.logo:SetTall(256)
     self.logo:Dock(TOP)
-    self.logo:DockMargin(0,0,0,ScrH*0.05)
 
-    self.nsteam = self:Add("DLabel")
-    self.nsteam:SetFont("nutBigCredits")
-    self.nsteam:SetText("NutScript Development Team")
-    self.nsteam:SizeToContents()
-    self.nsteam:Dock(TOP)
-    local dockLeft = ScrW*0.15 - (self.nsteam:GetContentSize())/2
-    self.nsteam:DockMargin(dockLeft,0,0,ScrH*0.025)
+    self.nsLabel = self:Add("DLabel")
+    self.nsLabel:SetFont("nutBigCredits")
+    self.nsLabel:SetText("NutScript")
+    self.nsLabel:SetContentAlignment(5)
+    self.nsLabel:SizeToContents()
+    self.nsLabel:Dock(TOP)
 
-    self.creditPanels = {}
-    local curNum = 0
+    self.repoLabel = self:Add("DLabel")
+    self.repoLabel:SetFont("nutSmallCredits")
+    self.repoLabel:SetText("https://github.com/NutScript")
+    self.repoLabel:SetMouseInputEnabled(true)
+    self.repoLabel:SetCursor("hand")
+    self.repoLabel:SetContentAlignment(5)
+    self.repoLabel:SizeToContents()
+    self.repoLabel:Dock(TOP)
+    self.repoLabel:DockMargin(0, 0, 0, 48)
+    self.repoLabel.DoClick = function()
+        gui.OpenURL("https://github.com/NutScript")
+    end
 
-    for k, v in ipairs(authorCredits) do
-        if k%2 ~= 0 then -- if k is odd
-            self.creditPanels[k] = self:Add("CreditsCreditsList")
-            curNum = k
-            self.creditPanels[curNum]:SetSize(self:GetWide(), ScrH*0.05)
-            self.creditPanels[curNum]:setPerson(v, true)
-            self.creditPanels[curNum]:Dock(TOP)
-            self.creditPanels[curNum]:DockMargin(0,0,0,ScrH*0.01)
-        else
-            self.creditPanels[curNum]:setPerson(v, false)
-            self.creditPanels[curNum]:Dock(TOP)
-            self.creditPanels[curNum]:DockMargin(0,0,0,ScrH*0.01)
+    self.contribList = self:Add("DIconLayout")
+    self.contribList:Dock(TOP)
+    self.contribList:SetSpaceX(8)
+    self.contribList:SetSpaceY(8)
+
+    if (#PLUGIN.contributorData == 0) then
+        http.Fetch("https://api.github.com/repos/NutScript/NutScript/contributors?per_page=100",
+            function(body, length, headers, code)
+                if (#PLUGIN.contributorData > 0) then
+                    return
+                end
+
+                local contributors = util.JSONToTable(body)
+
+                for k, v in pairs(contributors) do
+                    if (not PLUGIN.excludeList[v.login]) then
+                        table.insert(PLUGIN.contributorData, {url = v.html_url, avatar_url = v.avatar_url, name = v.login})
+                    end
+                end
+
+                if (self.RebuildContributors) then
+                    self:RebuildContributors()
+                end
+            end, function(message) end, {})
+    else
+        self:RebuildContributors()
+    end
+end
+
+function PANEL:RebuildContributors()
+    self.contribList:Clear()
+    self:LoadContributor(1, true)
+end
+
+function PANEL:LoadContributor(contributor, bLoadNextChunk)
+    if (PLUGIN.contributorData[contributor]) then
+        if (BRANCH == "x86-64") then
+            local container = self.contribList:Add("Panel")
+            container:SetSize(96, 116)
+            container.highlightAlpha = 0
+            container.Paint = function(this, width, height)
+                if (this:IsHovered()) then
+                    this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 128)
+                else
+                    this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 0)
+                end
+
+                surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha * 0.5))
+                surface.SetMaterial(nut.util.getMaterial("vgui/gradient-d"))
+                surface.DrawTexturedRect(0, 0, width, height)
+
+                surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha))
+                surface.DrawRect(0, height - 1, width, 1)
+            end
+            container.OnMousePressed = function(this, keyCode)
+                if (keyCode == 107) then
+                    gui.OpenURL(PLUGIN.contributorData[contributor].url)
+                end
+            end
+            container.OnMouseWheeled = function(this, delta)
+                self:OnMouseWheeled(delta)
+            end
+            container:SetCursor("hand")
+            container:SetTooltip(PLUGIN.contributorData[contributor].url)
+
+            local contributorPanel = container:Add("DHTML")
+            contributorPanel:SetHTML("<style>body {overflow: hidden; margin:0;} img {height: 100%; width: 100%; border-radius: 50%;}</style><img src=\"" .. PLUGIN.contributorData[contributor].avatar_url .. "\">")
+            contributorPanel:SetMouseInputEnabled(false)
+            contributorPanel:Dock(FILL)
+            contributorPanel:DockMargin(8, 8, 8, 8)
+   
+            if (bLoadNextChunk) then
+                contributorPanel.OnFinishLoadingDocument = function(this, url)
+                    -- load 3 at a time, nice balance between not eating up your cpu cycles and being quick to load all the avatars
+                    for i = 1, 3 do
+                        if (contributor + i > #PLUGIN.contributorData) then
+                            return
+                        end
+
+                        self:LoadContributor(contributor + i, i == 3)
+                    end
+                end
+            end
+
+            local button = container:Add("DLabel")
+            button:Dock(BOTTOM)
+            button:SetMouseInputEnabled(false)
+            button:SetFont("nutSmallCredits")
+            button:SetText(PLUGIN.contributorData[contributor].name)
+            button:SetContentAlignment(5)
+            button:SetTall(20)
+        else -- we're on 'main' branch, labels are made fast, just create them all at once
+           for _, v in ipairs(PLUGIN.contributorData) do
+                local button = self.contribList:Add("DLabel")
+                button:SetMouseInputEnabled(true)
+                button:SetText(v.name)
+                button:SetFont("nutSmallCredits")
+                button:SetCursor("hand")
+                button:SetTooltip(v.url)
+                button:SizeToContents()
+                button.highlightAlpha = 0
+                button.DoClick = function()
+                    gui.OpenURL(v.url)
+                end
+                button.OnMouseWheeled = function(this, delta)
+                    self:OnMouseWheeled(delta)
+                end
+                button.Paint = function(this, width, height)
+                    if (this:IsHovered()) then
+                        this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 128)
+                    else
+                        this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 0)
+                    end
+
+                    surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha * 0.5))
+                    surface.SetMaterial(nut.util.getMaterial("vgui/gradient-d"))
+                    surface.DrawTexturedRect(0, 0, width, height)
+
+                    surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha))
+                    surface.DrawRect(0, height - 1, width, 1)
+                end
+           end
         end
     end
-    self.contribPanel = self:Add("CreditsContribPanel")
-    self.contribPanel:SizeToChildren(true, true)
-    self.contribPanel:Dock(TOP)
 end
 
-function PANEL:Paint()
-end
-
-vgui.Register("nutCreditsList", PANEL, "DPanel")
+vgui.Register("nutCreditsList", PANEL, "DScrollPanel")
 
 hook.Add("BuildHelpMenu", "nutCreditsList", function(tabs)
 	tabs["Credits"] = function()
         if helpPanel then
             local credits = helpPanel:Add("nutCreditsList")
-            credits:Dock(TOP)
-            credits:DockMargin(ScrW*0.1, 0, ScrW*0.1, 0)
+            credits:Dock(FILL)
         end
         return ""
     end

--- a/plugins/nscredits.lua
+++ b/plugins/nscredits.lua
@@ -24,7 +24,7 @@ PLUGIN.NAME_OVERRIDES = {
     [2784192] = "Black Tea"
 }
 
-PLUGIN.CACHE_URL = "https://raw.githubusercontent.com/Miyoglow/NutScript/credits-cache"
+PLUGIN.CACHE_URL = "https://raw.githubusercontent.com/NutScript/NutScript/credits-cache"
 PLUGIN.MATERIAL_FOLDER = "ns/credits-cache"
 
 PLUGIN.contributorData = PLUGIN.contributorData or {

--- a/plugins/nscredits.lua
+++ b/plugins/nscredits.lua
@@ -10,26 +10,122 @@ if SERVER then return end
 PLUGIN.excludeList = {
     ["github_username_here"] = true
 }
-PLUGIN.contributorData = PLUGIN.contributorData or {}
+PLUGIN.nsCreators = {
+    ["Chessnut"] = true,
+    ["rebel1324"] = true,
+}
+PLUGIN.nsMaintainers = {
+    ["TovarischPootis"] = true,
+    ["zoephix"] = true
+}
 
-local logoMat = nut.util.getMaterial("nutscript/logo.png")
+local creatorHeight = ScreenScale(32)
+local maintainerHeight = ScreenScale(32)
+local contributorWidth = ScreenScale(32)
+
+PLUGIN.contributorData = PLUGIN.contributorData or {}
 
 surface.CreateFont("nutSmallCredits", {
     font = "Roboto Th",
-    size = 20,
-    weight = 400
+    size = ScreenScale(6),
+    weight = 100
 })
 
 surface.CreateFont("nutBigCredits", {
     font = "Roboto Th",
-    size = 32,
-    weight = 600
+    size = ScreenScale(12),
+    weight = 100
 })
 
 local PANEL = {}
 
+AccessorFunc(PANEL, "rowHeight", "RowHeight", FORCE_NUMBER)
+
+DEFINE_BASECLASS("Panel")
+
+function PANEL:Init()
+    self.seperator = vgui.Create("Panel", self)
+    self.seperator:Dock(TOP)
+    self.seperator:SetTall(1)
+    self.seperator.Paint = function(this, width, height)
+            surface.SetDrawColor(color_white)
+
+            surface.SetMaterial(nut.util.getMaterial("vgui/gradient-r"))
+            surface.DrawTexturedRect(0, 0, width * 0.5, height)
+
+            surface.SetMaterial(nut.util.getMaterial("vgui/gradient-l"))
+            surface.DrawTexturedRect(width * 0.5, 0, width * 0.5, height)
+        end
+    self.seperator:DockMargin(0, 4, 0, 4)
+
+    self.sectionLabel = vgui.Create("DLabel", self)
+    self.sectionLabel:Dock(TOP)
+    self.sectionLabel:SetFont("nutBigCredits")
+    self.sectionLabel:SetContentAlignment(4)
+end
+
+function PANEL:Clear()
+    for _, v in ipairs(self:GetChildren()) do
+        if (v != self.seperator and v != self.sectionLabel) then
+            v:Remove()
+        end
+    end
+end
+
+function PANEL:SetText(text)
+    self.sectionLabel:SetText(text)
+    self.sectionLabel:SizeToContents()
+end
+
+function PANEL:Add(pnl)
+    return BaseClass.Add(IsValid(self.currentRow) and self.currentRow or self:newRow(), pnl)
+end
+
+function PANEL:PerformLayout(width, height)
+    local tall = 0
+
+    for _, v in ipairs(self:GetChildren()) do
+        local lM, tM, rM, bM = v:GetDockMargin()
+        tall = tall + v:GetTall() + tM + bM
+
+        v:InvalidateLayout()
+    end
+
+    self:SetTall(tall)
+end
+
+function PANEL:newRow()
+    self.currentRow = vgui.Create("Panel", self)
+    self.currentRow:Dock(TOP)
+    self.currentRow:SetTall(self:GetRowHeight())
+    self.currentRow.PerformLayout = function(this)
+        local totalWidth = 0
+
+        for k, v in ipairs(this:GetChildren()) do
+            if (k == 1) then
+                v:DockMargin(0, 0, 0, 0)
+            end
+
+            totalWidth = totalWidth + v:GetWide() + v:GetDockMargin()
+
+            if (totalWidth > self:GetWide()) then
+                print(totalWidth, self:GetWide())
+                v:SetParent(self:newRow())
+            end
+        end
+
+        this:DockPadding(self:GetWide() * 0.5 - totalWidth * 0.5, 0, 0, 0)
+    end
+
+    return self.currentRow
+end
+
+vgui.Register("nutCreditsSpecialList", PANEL, "Panel")
+
+PANEL = {}
+
 function PANEL:Paint(w, h)
-    surface.SetMaterial(logoMat)
+    surface.SetMaterial(nut.util.getMaterial("nutscript/logo.png"))
     surface.SetDrawColor(255, 255, 255, 255)
     surface.DrawTexturedRect(w * 0.5 - 128, h * 0.5 - 128, 256, 256)
 end
@@ -38,6 +134,9 @@ vgui.Register("CreditsLogo", PANEL, "Panel")
 
 PANEL = {}
 
+local CONTRIB_PADDING = 8
+local CONTRIB_MARGIN = 16
+
 function PANEL:Init()
     if nut.gui.creditsPanel then
         nut.gui.creditsPanel:Remove()
@@ -45,7 +144,7 @@ function PANEL:Init()
     nut.gui.creditsPanel = self
 
     self.logo = self:Add("CreditsLogo")
-    self.logo:SetTall(256)
+    self.logo:SetTall(180)
     self.logo:Dock(TOP)
 
     self.nsLabel = self:Add("DLabel")
@@ -63,25 +162,55 @@ function PANEL:Init()
     self.repoLabel:SetContentAlignment(5)
     self.repoLabel:SizeToContents()
     self.repoLabel:Dock(TOP)
-    self.repoLabel:DockMargin(0, 0, 0, 48)
     self.repoLabel.DoClick = function()
         gui.OpenURL("https://github.com/NutScript")
     end
 
+    if (table.Count(PLUGIN.nsCreators) > 0) then
+        self.creatorList = self:Add("nutCreditsSpecialList")
+        self.creatorList:Dock(TOP)
+        self.creatorList:SetText("Creators")
+        self.creatorList:SetRowHeight(creatorHeight)
+        self.creatorList:DockMargin(0, 0, 0, 4)
+    end
+
+    if (table.Count(PLUGIN.nsMaintainers) > 0) then
+        self.maintainerList = self:Add("nutCreditsSpecialList")
+        self.maintainerList:Dock(TOP)
+        self.maintainerList:SetText("Maintainers")
+        self.maintainerList:SetRowHeight(maintainerHeight)
+        self.maintainerList:DockMargin(0, 0, 0, 4)
+    end
+
+    local seperator = self:Add("Panel")
+    seperator:Dock(TOP)
+    seperator:SetTall(1)
+    seperator.Paint = function(this, width, height)
+        surface.SetDrawColor(color_white)
+
+        surface.SetMaterial(nut.util.getMaterial("vgui/gradient-r"))
+        surface.DrawTexturedRect(0, 0, width * 0.5, height)
+
+        surface.SetMaterial(nut.util.getMaterial("vgui/gradient-l"))
+        surface.DrawTexturedRect(width * 0.5, 0, width * 0.5, height)
+    end
+    seperator:DockMargin(0, 4, 0, 4)
+
+    self.contribLabel = self:Add("DLabel")
+    self.contribLabel:SetFont("nutBigCredits")
+    self.contribLabel:SetText("Contributors")
+    self.contribLabel:SetContentAlignment(4)
+    self.contribLabel:SizeToContents()
+    self.contribLabel:Dock(TOP)
+
     self.contribList = self:Add("DIconLayout")
     self.contribList:Dock(TOP)
-    self.contribList:SetSpaceX(8)
-    self.contribList:SetSpaceY(8)
+    self.contribList:SetSpaceX(CONTRIB_MARGIN)
+    self.contribList:SetSpaceY(CONTRIB_MARGIN)
 
     if (#PLUGIN.contributorData == 0) then
         http.Fetch("https://api.github.com/repos/NutScript/NutScript/contributors?per_page=100",
             function(body, length, headers, code)
-                if (#PLUGIN.contributorData > 0) then
-                    self:RebuildContributors()
-
-                    return
-                end
-
                 local contributors = util.JSONToTable(body)
 
                 for k, v in pairs(contributors) do
@@ -89,54 +218,91 @@ function PANEL:Init()
                         table.insert(PLUGIN.contributorData, {url = v.html_url, avatar_url = v.avatar_url, name = v.login})
                     end
                 end
+
+                self:rebuildContributors()
             end, function(message) end, {})
     else
-        self:RebuildContributors()
+        self:rebuildContributors()
     end
 end
 
-function PANEL:RebuildContributors()
+function PANEL:rebuildContributors()
+    if (IsValid(self.creatorList)) then
+        self.creatorList:Clear()
+    end
+
+    if (IsValid(self.maintainerList)) then
+        self.maintainerList:Clear()
+    end
+
     self.contribList:Clear()
-    self:LoadContributor(1, true)
+    self:loadContributor(1, true)
 end
 
-function PANEL:LoadContributor(contributor, bLoadNextChunk)
+function PANEL:loadContributor(contributor, bLoadNextChunk)
     if (PLUGIN.contributorData[contributor]) then
-        if (BRANCH == "x86-64") then
-            local container = self.contribList:Add("Panel")
-            container:SetSize(96, 116)
-            container.highlightAlpha = 0
-            container.Paint = function(this, width, height)
-                if (this:IsHovered()) then
-                    this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 128)
-                else
-                    this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 0)
-                end
+        local isCreator = PLUGIN.nsCreators[PLUGIN.contributorData[contributor].name]
+        local isMaintainer = PLUGIN.nsMaintainers[PLUGIN.contributorData[contributor].name]
 
-                surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha * 0.5))
-                surface.SetMaterial(nut.util.getMaterial("vgui/gradient-d"))
-                surface.DrawTexturedRect(0, 0, width, height)
+        local container = vgui.Create("Panel")
+        
+        if (isCreator) then
+            self.creatorList:Add(container)
+        elseif (isMaintainer) then
+            self.maintainerList:Add(container)
+        else
+            self.contribList:Add(container)
+        end
 
-                surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha))
+        container:Dock((isCreator or isMaintainer) and LEFT or NODOCK)
+        container:DockMargin(unpack((isCreator or isMaintainer) and {CONTRIB_MARGIN, 0, 0, 0} or {0, 0, 0, 0}))
+
+        container:DockPadding(CONTRIB_PADDING, CONTRIB_PADDING, CONTRIB_PADDING, CONTRIB_PADDING)
+
+        container.highlightAlpha = 0
+        container.Paint = function(this, width, height)
+            if (this:IsHovered()) then
+                this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 128)
+            else
+                this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 0)
+            end
+
+            surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha * 0.5))
+            surface.SetMaterial((isCreator or isMaintainer) and nut.util.getMaterial("vgui/gradient-l") or nut.util.getMaterial("vgui/gradient-d"))
+            -- to textured rect or not to textured rect, that is the question
+            surface.DrawTexturedRect(0, 0, width, height)
+
+            surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha))
+
+            if (isCreator or isMaintainer) then
+                surface.DrawRect(0, 0, 1, height)
+            else
                 surface.DrawRect(0, height - 1, width, 1)
             end
-            container.OnMousePressed = function(this, keyCode)
-                if (keyCode == 107) then
-                    gui.OpenURL(PLUGIN.contributorData[contributor].url)
-                end
+        end
+        container.OnMousePressed = function(this, keyCode)
+            if (keyCode == 107) then
+                gui.OpenURL(PLUGIN.contributorData[contributor].url)
             end
-            container.OnMouseWheeled = function(this, delta)
-                self:OnMouseWheeled(delta)
-            end
-            container:SetCursor("hand")
-            container:SetTooltip(PLUGIN.contributorData[contributor].url)
+        end
+        container.OnMouseWheeled = function(this, delta)
+            self:OnMouseWheeled(delta)
+        end
+        container:SetCursor("hand")
+        container:SetTooltip(PLUGIN.contributorData[contributor].url)
 
+        if (BRANCH == "x86-64") then
             local contributorPanel = container:Add("DHTML")
-            contributorPanel:SetHTML("<style>body {overflow: hidden; margin:0;} img {height: 100%; width: 100%; border-radius: 50%;}</style><img src=\"" .. PLUGIN.contributorData[contributor].avatar_url .. "\">")
+            contributorPanel:SetHTML(
+                "<style>body {overflow: hidden; margin:0;} img {height: 100%; width: 100%; border-radius: 50%;}</style><img src=\""
+                .. PLUGIN.contributorData[contributor].avatar_url .. "\">"
+            )
             contributorPanel:SetMouseInputEnabled(false)
-            contributorPanel:Dock(FILL)
-            contributorPanel:DockMargin(8, 8, 8, 8)
-   
+
+            contributorPanel:Dock((isCreator or isMaintainer) and LEFT or FILL)
+            contributorPanel:DockMargin(unpack((isCreator or isMaintainer) and {0, 0, CONTRIB_PADDING, 0} or {0, 0, 0, CONTRIB_PADDING}))
+            contributorPanel:SetWide(isCreator and creatorHeight - CONTRIB_PADDING * 2 or isMaintainer and maintainerHeight - CONTRIB_PADDING * 2 or 0)
+
             if (bLoadNextChunk) then
                 contributorPanel.OnFinishLoadingDocument = function(this, url)
                     -- load 3 at a time, nice balance between not eating up your cpu cycles and being quick to load all the avatars
@@ -145,50 +311,31 @@ function PANEL:LoadContributor(contributor, bLoadNextChunk)
                             return
                         end
 
-                        self:LoadContributor(contributor + i, i == 3)
+                        self:loadContributor(contributor + i, i == 3)
                     end
                 end
             end
-
-            local button = container:Add("DLabel")
-            button:Dock(BOTTOM)
-            button:SetMouseInputEnabled(false)
-            button:SetFont("nutSmallCredits")
-            button:SetText(PLUGIN.contributorData[contributor].name)
-            button:SetContentAlignment(5)
-            button:SetTall(20)
-        else -- we're on 'main' branch, labels are made fast, just create them all at once
-           for _, v in ipairs(PLUGIN.contributorData) do
-                local button = self.contribList:Add("DLabel")
-                button:SetMouseInputEnabled(true)
-                button:SetText(v.name)
-                button:SetFont("nutSmallCredits")
-                button:SetCursor("hand")
-                button:SetTooltip(v.url)
-                button:SizeToContents()
-                button.highlightAlpha = 0
-                button.DoClick = function()
-                    gui.OpenURL(v.url)
-                end
-                button.OnMouseWheeled = function(this, delta)
-                    self:OnMouseWheeled(delta)
-                end
-                button.Paint = function(this, width, height)
-                    if (this:IsHovered()) then
-                        this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 128)
-                    else
-                        this.highlightAlpha = Lerp(FrameTime() * 16, this.highlightAlpha, 0)
-                    end
-
-                    surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha * 0.5))
-                    surface.SetMaterial(nut.util.getMaterial("vgui/gradient-d"))
-                    surface.DrawTexturedRect(0, 0, width, height)
-
-                    surface.SetDrawColor(ColorAlpha(nut.config.get("color"), this.highlightAlpha))
-                    surface.DrawRect(0, height - 1, width, 1)
-                end
-           end
+        elseif (bLoadNextChunk) then
+            for i = 1, #PLUGIN.contributorData - 1 do
+                self:loadContributor(contributor + i)
+            end
         end
+
+        local button = container:Add("DLabel")
+        button:SetMouseInputEnabled(false)
+        button:SetText(PLUGIN.contributorData[contributor].name)
+        button:SetContentAlignment(5)
+
+        button:Dock((isCreator or isMaintainer) and FILL or BOTTOM)
+        button:SetFont((isCreator or isMaintainer) and "nutBigCredits" or "nutSmallCredits")
+        button:SizeToContents()
+
+        container:SetSize(
+            isCreator and button:GetWide() + creatorHeight + CONTRIB_PADDING
+            or isMaintainer and button:GetWide() + maintainerHeight + CONTRIB_PADDING
+            or contributorWidth,
+            button:GetTall() + (BRANCH == "x86-64" and contributorWidth or CONTRIB_PADDING) + CONTRIB_PADDING
+        )
     end
 end
 

--- a/plugins/nscredits.lua
+++ b/plugins/nscredits.lua
@@ -30,8 +30,8 @@ PLUGIN.contributorData = PLUGIN.contributorData or {
     {url = "https://github.com/Chessnut", avatar_url = "https://avatars.githubusercontent.com/u/1689094?v=4", name = "Chessnut", id = 1689094},
     {url = "https://github.com/rebel1324", avatar_url = "https://avatars.githubusercontent.com/u/2784192?v=4", name = "Black Tea", id = 2784192}
 }
-PLUGIN.encodedAvatarData = {}
 
+PLUGIN.encodedAvatarData = PLUGIN.encodedAvatarData or {}
 PLUGIN.fetchedContributors = PLUGIN.fetchedContributors or false
 
 local creatorHeight = ScreenScale(32)
@@ -326,33 +326,26 @@ function PANEL:loadContributor(contributor, bLoadNextChunk)
         avatar:DockMargin(unpack((isCreator or isMaintainer) and {0, 0, contributorPadding, 0} or {0, 0, 0, contributorPadding}))
         avatar:SetWide(isCreator and creatorHeight - contributorPadding * 2 or isMaintainer and maintainerHeight - contributorPadding * 2 or 0)
 
-        if (BRANCH == "x86-64") then
-            avatar:SetHTML(
-                "<style>body {overflow: hidden; margin:0;} img {height: 100%; width: 100%; border-radius: 50%;}</style><img src=\""
-                .. PLUGIN.contributorData[contributor].avatar_url .. "\">"
-            )
-        else
-            if (!PLUGIN.encodedAvatarData[contributor]) then
-                HTTP({
-                    url = PLUGIN.contributorData[contributor].avatar_url,
-                    method = "GET",
-                    success = function(code, body)
-                        PLUGIN.encodedAvatarData[contributor] = util.Base64Encode(body)
-        
-                        if (IsValid(avatar)) then
-                            avatar:SetHTML(
-                                "<style>body {overflow: hidden; margin:0;} img {height: 100%; width: 100%; border-radius: 50%;}</style><img src=\"data:image/png;base64,"
-                                .. util.Base64Encode(body) .. "\">"
-                            )
-                        end
+        if (!PLUGIN.encodedAvatarData[contributor]) then
+            HTTP({
+                url = PLUGIN.contributorData[contributor].avatar_url,
+                method = "GET",
+                success = function(code, body)
+                    PLUGIN.encodedAvatarData[contributor] = util.Base64Encode(body)
+    
+                    if (IsValid(avatar)) then
+                        avatar:SetHTML(
+                            "<style>body {overflow: hidden; margin:0;} img {height: 100%; width: 100%; border-radius: 50%;}</style><img src=\"data:image/png;base64,"
+                            .. PLUGIN.encodedAvatarData[contributor] .. "\">"
+                        )
                     end
-                })
-            else
-                avatar:SetHTML(
-                    "<style>body {overflow: hidden; margin:0;} img {height: 100%; width: 100%; border-radius: 50%;}</style><img src=\"data:image/png;base64,"
-                    .. PLUGIN.encodedAvatarData[contributor] .. "\">"
-                )
-            end
+                end
+            })
+        else
+            avatar:SetHTML(
+                "<style>body {overflow: hidden; margin:0;} img {height: 100%; width: 100%; border-radius: 50%;}</style><img src=\"data:image/png;base64,"
+                .. PLUGIN.encodedAvatarData[contributor] .. "\">"
+            )
         end
 
         if (bLoadNextChunk) then


### PR DESCRIPTION
## Motivation:
Developers for NutScript are numbered many, the limited, simple and (in my opinion) amateur design previously done for the credits page did not give the proper dues to all contributors. This new design gives whoever works on the project a place in the framework.

## Challenges:
From the beginning I wanted to show the GitHub avatars from the contributors, this poses a significant challenge as GitHub api/cdn does not support TLS 1.0 (for obvious reasons), and the Awesomium branch only supports up to 1.0. So I was left with two options,

1. Make a website that got the contributors avatars and then serve them over TLS 1.0 
(I believe this is the issue and could solve it)
2. Only support avatars on the x86-64 branch of Garry's Mod

I've picked option 2 as of now. So I've had to create two layouts for the credits page as shown below.
Technically there is a third option, but I'm not doing it.

## Layout for x86-64 branch:
![Layout for x86-64 branch](https://i.imgur.com/WdxIyo7.png)

## Layout for 'main' branch:
![Layout for 'main' branch](https://i.imgur.com/jANDorH.png)

## Closing Remarks:
This is posted as a Draft PR firstly because of the possibility of changing to option 1 before merging, and secondly because the UI currently has minimal scaling, importantly, the fonts don't scale, the logo doesn't scale, and the contributor boxes don't scale. (this could be a minor issue though as the scaling on the old credits page was not much, if at all better)

This is the first in refreshes to the UI I have planned.