### PR TITLE
Fix server error when a user doesn't input an argument into /plytransfer

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -560,11 +560,16 @@ nut.command.add("plytransfer", {
 	syntax = "<string name> <string faction>",
 	onRun = function(client, arguments)
 		local target = nut.command.findPlayer(client, arguments[1])
+
+		if (not IsValid(target)) then
+			return
+		end
+
 		local faction = nut.command.findFaction(client, table.concat(arguments, " ", 2))
 		local character = target:getChar()
 
-		if (not IsValid(target) or not character) then
-			return "@plyNotExist"
+		if (not character) then
+			return
 		end
 
 		-- Find the specified faction.


### PR DESCRIPTION
from commit:
`target:getChar() assumes target exists, return earlier if it doesn't. get rid of duplicate string notification.`

Secondly I want to make it known the reason I named this branch "temp-fix" is because I have a strong want to add to the inbuilt argument system an automatic argument type checking/handling and possibly even deprecating the usage of things like ".findPlayer()" in commands by automatically running something like that when a player is wanted. Still figuring out the details as we'll want to make sure we retain backwards compatibility with the argument system used right now.