### PR TITLE
Add an option to invert direction of weapon select scroll

### DIFF
--- a/gamemode/languages/sh_english.lua
+++ b/gamemode/languages/sh_english.lua
@@ -268,4 +268,6 @@ LANGUAGE = {
 	-- 2023 patch
 
 	togglePluginsDesc = "Selected Plugins will be disabled.\nThe map must be restarted after making changes!",
+
+	invertWepSelectScroll = "Invert direction of weapon selection scroll",
 }

--- a/plugins/wepselect.lua
+++ b/plugins/wepselect.lua
@@ -193,10 +193,13 @@ if (CLIENT) then
 
 		local total = table.Count(client:GetWeapons())
 
-		local bInvert = NUT_CVAR_WEPSELECT_INVERT:GetBool()
-		local invprev, invnext = bind:find("invprev"), bind:find("invnext")
+		local invprev, invnext = isnumber(bind:find("invprev")), isnumber(bind:find("invnext"))
 
-		if (!bInvert and invprev or bInvert and invnext) then
+		if (NUT_CVAR_WEPSELECT_INVERT:GetBool()) then
+			invprev, invnext = invnext, invprev
+		end
+
+		if (invprev) then
 			self.index = self.index - 1
 			if (self.index < 1) then
 				self.index = total
@@ -204,7 +207,7 @@ if (CLIENT) then
 
 			self:onIndexChanged()
 			return true
-		elseif (!bInvert and invnext or bInvert and invprev) then
+		elseif (invnext) then
 			self.index = self.index + 1
 			if (self.index > total) then
 				self.index = 1

--- a/plugins/wepselect.lua
+++ b/plugins/wepselect.lua
@@ -193,32 +193,21 @@ if (CLIENT) then
 
 		local total = table.Count(client:GetWeapons())
 
-		if (bind:find("invprev")) then
-			if (NUT_CVAR_WEPSELECT_INVERT:GetBool()) then
-				self.index = self.index + 1
-				if (self.index > total) then
-					self.index = 1
-				end
-			else
-				self.index = self.index - 1
-				if (self.index < 1) then
-					self.index = total
-				end
+		local bInvert = NUT_CVAR_WEPSELECT_INVERT:GetBool()
+		local invprev, invnext = bind:find("invprev"), bind:find("invnext")
+
+		if (!bInvert and invprev or bInvert and invnext) then
+			self.index = self.index - 1
+			if (self.index < 1) then
+				self.index = total
 			end
 
 			self:onIndexChanged()
 			return true
-		elseif (bind:find("invnext")) then
-			if (NUT_CVAR_WEPSELECT_INVERT:GetBool()) then
-				self.index = self.index - 1
-				if (self.index < 1) then
-					self.index = total
-				end
-			else
-				self.index = self.index + 1
-				if (self.index > total) then
-					self.index = 1
-				end
+		elseif (!bInvert and invnext or bInvert and invprev) then
+			self.index = self.index + 1
+			if (self.index > total) then
+				self.index = 1
 			end
 
 			self:onIndexChanged()

--- a/plugins/wepselect.lua
+++ b/plugins/wepselect.lua
@@ -9,6 +9,10 @@ local pi = math.pi
 
 if (CLIENT) then
 
+	nut.lang.stored["english"]["invertWepselectScroll"] = "Invert direction of weapon selection scroll"
+
+	NUT_CVAR_WEPSELECT_INVERT = CreateClientConVar("nut_wepselect_invert", 0, true)
+
 	PLUGIN.index = PLUGIN.index or 1
 	PLUGIN.deltaIndex = PLUGIN.deltaIndex or PLUGIN.index
 	PLUGIN.infoAlpha = PLUGIN.infoAlpha or 0
@@ -159,6 +163,20 @@ if (CLIENT) then
 		end
 	end
 
+	function PLUGIN:SetupQuickMenu(menu)
+		menu:addCategory(self.name)
+
+		local button = menu:addCheck(L"invertWepselectScroll", function(panel, state)
+			if (state) then
+				RunConsoleCommand("nut_wepselect_invert", "1")
+			else
+				RunConsoleCommand("nut_wepselect_invert", "0")
+			end
+		end, NUT_CVAR_WEPSELECT_INVERT:GetBool())
+
+		menu:addSpacer()
+	end
+
 	function PLUGIN:PlayerBindPress(client, bind, pressed)
 		local weapon = client:GetActiveWeapon()
 		local lPly = LocalPlayer()
@@ -176,17 +194,31 @@ if (CLIENT) then
 		local total = table.Count(client:GetWeapons())
 
 		if (bind:find("invprev")) then
-			self.index = self.index - 1
-			if (self.index < 1) then
-				self.index = total
+			if (NUT_CVAR_WEPSELECT_INVERT:GetBool()) then
+				self.index = self.index + 1
+				if (self.index > total) then
+					self.index = 1
+				end
+			else
+				self.index = self.index - 1
+				if (self.index < 1) then
+					self.index = total
+				end
 			end
 
 			self:onIndexChanged()
 			return true
 		elseif (bind:find("invnext")) then
-			self.index = self.index + 1
-			if (self.index > total) then
-				self.index = 1
+			if (NUT_CVAR_WEPSELECT_INVERT:GetBool()) then
+				self.index = self.index - 1
+				if (self.index < 1) then
+					self.index = total
+				end
+			else
+				self.index = self.index + 1
+				if (self.index > total) then
+					self.index = 1
+				end
 			end
 
 			self:onIndexChanged()

--- a/plugins/wepselect.lua
+++ b/plugins/wepselect.lua
@@ -8,9 +8,6 @@ local RunConsoleCommand, LocalPlayer, math, color_white, surface = RunConsoleCom
 local pi = math.pi
 
 if (CLIENT) then
-
-	nut.lang.stored["english"]["invertWepselectScroll"] = "Invert direction of weapon selection scroll"
-
 	NUT_CVAR_WEPSELECT_INVERT = CreateClientConVar("nut_wepselect_invert", 0, true)
 
 	PLUGIN.index = PLUGIN.index or 1
@@ -166,7 +163,7 @@ if (CLIENT) then
 	function PLUGIN:SetupQuickMenu(menu)
 		menu:addCategory(self.name)
 
-		local button = menu:addCheck(L"invertWepselectScroll", function(panel, state)
+		local button = menu:addCheck(L"invertWepSelectScroll", function(panel, state)
 			if (state) then
 				RunConsoleCommand("nut_wepselect_invert", "1")
 			else


### PR DESCRIPTION
Self explanatory.

Adds a new convar `nut_wepselect_invert` which controls the direction of the weapon select scroll, also adds that to quick settings options with an English Locale only by default.

![Quick settings](https://i.imgur.com/d7uMAYs.png)

I wasn't sure if there was a different way to add a language entry or not, I didn't see one, so I just directly modified `nut.lang.stored["english"]`