### PR TITLE
Command arguments overhaul

### DIFF
--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -1,7 +1,7 @@
 nut.chat = nut.chat or {}
 nut.chat.classes = nut.char.classes or {}
 
-local DUMMY_COMMAND = {syntax = "<string text>", onRun = function() end}
+local DUMMY_COMMAND = {arguments = "string", onRun = function(_, text) end}
 
 if (not nut.command) then
 	include("sh_command.lua")
@@ -393,7 +393,7 @@ end
 
 -- Private messages between players.
 nut.chat.register("pm", {
-	format = "[PM] %s: %s.",
+	format = "[PM] %s: %s",
 	color = Color(249, 211, 89),
 	filter = "pm",
 	deadCanChat = true

--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -6,15 +6,15 @@ local COMMAND_PREFIX = "/"
 
 function nut.command.add(name, data)
 	if (!isstring(name)) then
-		return ErrorNoHaltWithStack("nut.command.add expected string for #1 argument but got: " .. nut.type(name))
+		return ErrorNoHaltWithStack("nut.command.add expected string for #1 argument but got: " .. nut.type.getName(nut.type(name)))
 	end
 
 	if (!istable(data)) then
-		return ErrorNoHaltWithStack("nut.command.add(\"" .. name .. "\") expected table for #2 argument but got: " .. nut.type(data))
+		return ErrorNoHaltWithStack("nut.command.add(\"" .. name .. "\") expected table for #2 argument but got: " .. nut.type.getName(nut.type(data)))
 	end
 
 	if (!isfunction(data.onRun)) then
-		return ErrorNoHaltWithStack("nut.command.add(\"" .. name .. "\") expected an onRun function in #2 argument but got: " .. nut.type(data.onRun))
+		return ErrorNoHaltWithStack("nut.command.add(\"" .. name .. "\") expected an onRun function in #2 argument but got: " .. nut.type.getName(nut.type(data.onRun)))
 	end
 
 	-- new argument system
@@ -308,10 +308,12 @@ if (SERVER) then
 							end
 
 							if (argument) then
-								local multipleTypes = nut.type.getMultiple(nutType)
+								local multipleTypes = table.Reverse(nut.type.getMultiple(nutType))
 								local failed
 
-								for _, v in ipairs(multipleTypes) do
+								-- string types are an early bit value in types, but we want to parse/assert them last, so go through the types we have backwards
+								for i = #multipleTypes, 1, -1 do
+									local v = multipleTypes[i]
 									local assertion = nut.type.assert(v, argument)
 
 									if (assertion) then
@@ -326,7 +328,7 @@ if (SERVER) then
 										if (nut.type.getName(v) == "player" or nut.type.getName(v) == "character") then
 											failed = "Could not find the target \'" .. argument .. "\'"
 										else
-											failed = "Wrong type to #" .. i .. " argument, expected \'" .. nut.type.getName(nutType) .. "\' got \'" .. nut.type(argument) .. "\'"
+											failed = "Wrong type to #" .. i .. " argument, expected \'" .. nut.type.getName(nutType) .. "\' got \'" .. nut.type.getName(nut.type(argument)) .. "\'"
 										end
 									end
 								end

--- a/gamemode/core/libs/sh_type.lua
+++ b/gamemode/core/libs/sh_type.lua
@@ -171,7 +171,9 @@ nut.type.addResolve("player", function(value)
 	end
 
 	if (isstring(value)) then
-		return nut.util.findPlayer(value)
+		if (nut.util.findPlayer(value)) then
+			return nut.util.findPlayer(value)
+		end
 	end
 
 	return false, "Could not find the player \'" .. value .. "\'"
@@ -181,9 +183,11 @@ nut.type.addResolve("character", function(value)
 		return value
 	end
 
+	local client = nut.type.resolve(nut.type.player, value)
+
 	-- if the value can resolve to a player then we probably want the player's character
-	if (nut.type.resolve(nut.type.player, value)) then
-		return nut.type.resolve(nut.type.player, value):getChar()
+	if (client and client:getChar()) then
+		return client:getChar()
 	end
 
 	if (isstring(value)) then

--- a/gamemode/core/libs/sh_type.lua
+++ b/gamemode/core/libs/sh_type.lua
@@ -99,3 +99,13 @@ nut.type.add("player", function(value)
 		return nut.util.findPlayer(value)
 	end
 end)
+nut.type.add("character", function(value)
+	if (isentity(value)) then
+		return value.getChar and value:GetChar()
+	end
+
+	if (isstring(value)) then
+		local client = nut.util.findPlayer(value)
+		return client and client:getChar()
+	end
+end)

--- a/gamemode/core/libs/sh_type.lua
+++ b/gamemode/core/libs/sh_type.lua
@@ -1,0 +1,101 @@
+
+nut.type = nut.type or {}
+nut.type.map = nut.type.map or {}
+nut.type.types = nut.type.types or {}
+nut.type.bitsum = nut.type.bitsum  or 0
+
+-- _G.type but for nut.type
+function nut.type.type(...)
+	local value = select(1, ...)
+	value = (istable(value) and value == nut.type) and select(2, ...) or value
+
+	if (istable(value)) then
+		if (value.nutType and nut.type.map[value.nutType]) then
+			return nut.type.types[nut.type.map[value.nutType]].name
+		end
+
+		for _, v in ipairs(nut.type.types) do
+			if (v.assertion and v.assertion(value)) then
+				return v.name
+			end
+		end
+	end
+
+	return type(value)
+end
+
+function nut.type.add(name, assertion)
+	if (nut.type[name]) then
+		nut.type.types[nut.type.map[name]].assertion = assertion
+
+		return
+	end
+
+	if (!isstring(name)) then
+		error("nut.type.add expected string for #1 input but got: " .. type(name))
+	end
+
+	if (assertion and !isfunction(assertion)) then
+		error("nut.type.add expected function for #2 input but got: " .. type(assertion))
+	end
+
+	local pow2 = 2 ^ (#nut.type.types + 1)
+
+	nut.type.bitsum = bit.bor(nut.type.bitsum, pow2)
+
+	nut.type[pow2] = name
+	nut.type[name] = pow2
+
+	nut.type.map[pow2] = table.insert(nut.type.types, {assertion = assertion, name = name})
+	nut.type.map[name] = nut.type.map[pow2]
+end
+
+function nut.type.assert(nutType, value)
+	if (nut.type.map[nutType]) then
+		nutType = nut.type.types[nut.type.map[nutType]]
+
+		if (nutType.assertion) then
+			return nutType.assertion(value)
+		else
+			return true
+		end
+	end
+end
+
+function nut.type.getName(nutType)
+	if (nut.type.map[nutType]) then
+		nutType = nut.type.types[nut.type.map[nutType]]
+
+		if (nutType.name) then
+			return nutType.name
+		end
+	-- could be a 'bit.bor(x, nut.type.optional)', let's see if it is
+	elseif (nut.type.isOptional(nutType)) then
+		local xor = bit.bxor(nutType, nut.type.optional)
+
+		if (xor) then
+			return nut.type.getName(xor)
+		end
+	end
+end
+
+nut.type = setmetatable(nut.type, {__call = nut.type.type})
+
+nut.type.add("optional")
+function nut.type.isOptional(num)
+	return isnumber(num) and bit.band(num, nut.type.optional) == nut.type.optional
+end
+
+nut.type.add("string", function(value) return isstring(value) end)
+nut.type.add("number", function(value) return isnumber(tonumber(value)) end)
+nut.type.add("bool", function(value) return isbool(value) end)
+nut.type.add("steamid64", function(value) return isstring(value) and string.format("%017.17s", value) == value end)
+nut.type.add("player", function(value)
+	if (isentity(value)) then
+		return value:IsPlayer() and value
+	end
+
+	if (isstring(value)) then
+		return nut.util.findPlayer(value)
+	end
+end)

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -233,7 +233,7 @@ nut.command.add("charunban", {
 			return L("charSearching", client)
 		end
 
-		if (target.getPlayer) then
+		if (nut.type(target) == nut.type.character) then
 			if (target:getData("banned")) then
 				target:setData("banned", nil)
 				target:setData("permakilled", nil)

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -220,7 +220,7 @@ nut.command.add("charban", {
 	adminOnly = true,
 	arguments = nut.type.character,
 	onRun = function(client, target)
-		nut.util.notifyLocalized("charBan", client:Name(), target:getName())
+		nut.util.notifyLocalized("charBan", IsValid(client) and client:Name() or "System", target:getName())
 		target:ban()
 	end
 })
@@ -237,10 +237,14 @@ nut.command.add("charunban", {
 			if (target:getData("banned")) then
 				target:setData("banned", nil)
 				target:setData("permakilled", nil)
-				nut.util.notifyLocalized("charUnBan", nil, client:Name(), target:getName())
+				nut.util.notifyLocalized("charUnBan", nil, IsValid(client) and client:Name() or "System", target:getName())
 				return
 			else
-				client:notifyLocalized("charNotBanned")
+				if (IsValid(client)) then
+					client:notifyLocalized("charNotBanned")
+				else
+					print("This character is not banned.")
+				end
 				return
 			end
 		end
@@ -261,10 +265,7 @@ nut.command.add("charunban", {
 				data.banned = nil
 
 				nut.db.updateTable({_data = data}, nil, "characters", "_id = " .. charID)
-				nut.util.notifyLocalized("charUnBan", nil, client:Name(), nut.char.loaded[charID]:getName())
-			else
-				client:notify("Could not find the character \'" .. target .. "\'")
-				return
+				nut.util.notifyLocalized("charUnBan", nil, IsValid(client) and client:Name() or "System", nut.char.loaded[charID]:getName())
 			end
 		end)
 	end

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -1,6 +1,6 @@
 
 nut.command.add("roll", {
-	arguments = bit.bor(nut.type.number, nut.type.optional),
+	arguments = nut.type.tor(nut.type.number, nut.type.optional),
 	onRun = function(client, maximum)
 		nut.chat.send(client, "roll", math.random(0, math.min(tonumber(maximum) or 100, 100)))
 	end
@@ -42,7 +42,7 @@ nut.command.add("reply", {
 })
 
 nut.command.add("setvoicemail", {
-	arguments = bit.bor(nut.type.string, nut.type.optional),
+	arguments = nut.type.tor(nut.type.string, nut.type.optional),
 	onRun = function(client, message)
 		if (message and message:find("%S")) then
 			client:setNutData("vm", message:sub(1, 240))
@@ -60,7 +60,7 @@ nut.command.add("flaggive", {
 	adminOnly = true,
 	arguments = {
 		nut.type.character,
-		bit.bor(nut.type.string, nut.type.optional)
+		nut.type.tor(nut.type.string, nut.type.optional)
 	},
 	onRun = function(client, target, flags)
 		if (not flags) then
@@ -88,7 +88,7 @@ nut.command.add("flagtake", {
 	adminOnly = true,
 	arguments = {
 		nut.type.character,
-		bit.bor(nut.type.string, nut.type.optional)
+		nut.type.tor(nut.type.string, nut.type.optional)
 	},
 	onRun = function(client, target, flags)
 		if (not flags) then
@@ -136,7 +136,7 @@ nut.command.add("charsetbodygroup", {
 	arguments = {
 		nut.type.character,
 		nut.type.string,
-		bit.bor(nut.type.number, nut.type.optional)
+		nut.type.tor(nut.type.number, nut.type.optional)
 	},
 	onRun = function(client, target, bodygroup, value)
 		local index = target:getPlayer():FindBodygroupByName(bodygroup)
@@ -162,7 +162,7 @@ nut.command.add("charsetname", {
 	adminOnly = true,
 	arguments = {
 		nut.type.character,
-		bit.bor(nut.type.string, nut.type.optional)
+		nut.type.tor(nut.type.string, nut.type.optional)
 	},
 	onRun = function(client, target, name)
 		if (not name) then
@@ -181,7 +181,7 @@ nut.command.add("chargiveitem", {
 	arguments = {
 		nut.type.character,
 		nut.type.item,
-		bit.bor(nut.type.number, nut.type.optional),
+		nut.type.tor(nut.type.number, nut.type.optional),
 	},
 	onRun = function(client, target, name, amount)
 		local item = name.uniqueID
@@ -227,7 +227,7 @@ nut.command.add("charban", {
 
 nut.command.add("charunban", {
 	adminOnly = true,
-	arguments = bit.bor(nut.type.character, nut.type.string),
+	arguments = nut.type.tor(nut.type.character, nut.type.string),
 	onRun = function(client, target)
 		if ((client.nutNextSearch or 0) >= CurTime()) then
 			return L("charSearching", client)
@@ -396,7 +396,7 @@ nut.command.add("plyunwhitelist", {
 })
 
 nut.command.add("fallover", {
-	arguments = bit.bor(nut.type.number, nut.type.optional),
+	arguments = nut.type.tor(nut.type.number, nut.type.optional),
 	onRun = function(client, time)
 		if (not isnumber(time)) then
 			time = 5
@@ -415,42 +415,20 @@ nut.command.add("fallover", {
 })
 
 nut.command.add("beclass", {
-	arguments = nut.type.number,
-	onRun = function(client, class)
+	arguments = nut.type.class,
+	onRun = function(client, name)
+		local class = name
+
 		local char = client:getChar()
 
 		if (IsValid(client) and char) then
-			local num = isnumber(tonumber(class)) and tonumber(class) or -1
-
-			if (nut.class.list[num]) then
-				local v = nut.class.list[num]
-
-				if (char:joinClass(num)) then
-					client:notifyLocalized("becomeClass", L(v.name, client))
-
-					return
-				else
-					client:notifyLocalized("becomeClassFail", L(v.name, client))
-
-					return
-				end
+			if (char:joinClass(class.index)) then
+				client:notifyLocalized("becomeClass", L(class.name, client))
+				return
 			else
-				for k, v in ipairs(nut.class.list) do
-					if (nut.util.stringMatches(v.uniqueID, class) or nut.util.stringMatches(L(v.name, client), class)) then
-						if (char:joinClass(k)) then
-							client:notifyLocalized("becomeClass", L(v.name, client))
-
-							return
-						else
-							client:notifyLocalized("becomeClassFail", L(v.name, client))
-
-							return
-						end
-					end
-				end
+				client:notifyLocalized("becomeClassFail", L(class.name, client))
+				return
 			end
-
-			client:notifyLocalized("invalid", L("class", client))
 		else
 			client:notifyLocalized("illegalAccess")
 		end
@@ -458,7 +436,7 @@ nut.command.add("beclass", {
 })
 
 nut.command.add("chardesc", {
-	arguments = bit.bor(nut.type.string, nut.type.optional),
+	arguments = nut.type.tor(nut.type.string, nut.type.optional),
 	onRun = function(client, desc)
 		if (not desc or not desc:find("%S")) then
 			return client:requestString("@chgDesc", "@chgDescDesc", function(text)

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -1,29 +1,30 @@
+
 nut.command.add("roll", {
-	syntax = "[number maximum]",
-	onRun = function(client, arguments)
-		nut.chat.send(client, "roll", math.random(0, math.min(tonumber(arguments[1]) or 100, 100)))
+	arguments = {
+		bit.bor(nut.type.number, nut.type.optional)
+	},
+	onRun = function(client, maximum)
+		nut.chat.send(client, "roll", math.random(0, math.min(tonumber(maximum) or 100, 100)))
 	end
 })
 
 nut.command.add("pm", {
-	syntax = "<string target> <string message>",
-	onRun = function(client, arguments)
-		local message = table.concat(arguments, " ", 2)
-		local target = nut.command.findPlayer(client, arguments[1])
+	arguments = {
+		nut.type.player,
+		nut.type.string
+	},
+	onRun = function(client, target, message)
+		local voiceMail = target:getNutData("vm")
 
-		if (IsValid(target)) then
-			local voiceMail = target:getNutData("vm")
+		if (voiceMail and voiceMail:find("%S")) then
+			return target:Name()..": "..voiceMail
+		end
 
-			if (voiceMail and voiceMail:find("%S")) then
-				return target:Name()..": "..voiceMail
-			end
+		if ((client.nutNextPM or 0) < CurTime()) then
+			nut.chat.send(client, "pm", message, false, {client, target})
 
-			if ((client.nutNextPM or 0) < CurTime()) then
-				nut.chat.send(client, "pm", message, false, {client, target})
-
-				client.nutNextPM = CurTime() + 0.5
-				target.nutLastPM = client
-			end
+			client.nutNextPM = CurTime() + 0.5
+			target.nutLastPM = client
 		end
 	end
 })

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -325,7 +325,7 @@ nut.command.add("charsetmoney", {
 nut.command.add("dropmoney", {
 	arguments = nut.type.number,
 	onRun = function(client, money)
-		local amount = math.floor(number)
+		local amount = math.floor(money)
 
 		if (amount < 1) then
 			return client:notify("Amount must be greater than zero.")

--- a/gamemode/core/sh_util.lua
+++ b/gamemode/core/sh_util.lua
@@ -97,27 +97,16 @@ end
 
 -- Returns true if a string is a 32-bit SteamID.
 function nut.util.isSteamID(value)
-	if (string.match(value, "STEAM_(%d+):(%d+):(%d+)")) then
-		return true
-	end
-	return false
+	return nut.type.assert(nut.type.steamid, value)
 end
 
 -- Finds a player by matching their name or steam id.
 function nut.util.findPlayer(identifier, allowPatterns)
-	if (nut.util.isSteamID(identifier)) then
-		return player.GetBySteamID(identifier)
-	end
-
 	if (!allowPatterns) then
 		identifier = string.PatternSafe(identifier)
 	end
 
-	for _, v in ipairs(player.GetAll()) do
-		if (nut.util.stringMatches(v:Name(), identifier)) then
-			return v
-		end
-	end
+	return nut.type.resolve(nut.type.player, identifier)
 end
 
 function nut.util.gridVector(vec, gridSize)

--- a/plugins/3dpanel.lua
+++ b/plugins/3dpanel.lua
@@ -143,12 +143,13 @@ end
 
 nut.command.add("paneladd", {
 	adminOnly = true,
-	syntax = "<string url> [number w] [number h] [number scale]",
-	onRun = function(client, arguments)
-		if (!arguments[1]) then
-			return L("invalidArg", client, 1)
-		end
-
+	arguments = {
+		nut.type.string,
+		nut.type.tor(nut.type.number, nut.type.optional),
+		nut.type.tor(nut.type.number, nut.type.optional),
+		nut.type.tor(nut.type.number, nut.type.optional)
+	},
+	onRun = function(client, url, w, h, scale)
 		-- Get the position and angles of the panel.
 		local trace = client:GetEyeTrace()
 		local position = trace.HitPos
@@ -157,7 +158,7 @@ nut.command.add("paneladd", {
 		angles:RotateAroundAxis(angles:Forward(), 90)
 
 		-- Add the panel.
-		PLUGIN:addPanel(position + angles:Up()*0.1, angles, arguments[1], tonumber(arguments[2]), tonumber(arguments[3]), tonumber(arguments[4]))
+		PLUGIN:addPanel(position + angles:Up()*0.1, angles, url, w, h, scale)
 
 		-- Tell the player the panel was added.
 		return L("panelAdded", client)
@@ -166,13 +167,13 @@ nut.command.add("paneladd", {
 
 nut.command.add("panelremove", {
 	adminOnly = true,
-	syntax = "[number radius]",
-	onRun = function(client, arguments)
+	arguments = nut.type.tor(nut.type.number, nut.type.optional),
+	onRun = function(client, radius)
 		-- Get the origin to remove panel.
 		local trace = client:GetEyeTrace()
 		local position = trace.HitPos
 		-- Remove the panel(s) and get the amount removed.
-		local amount = PLUGIN:removePanel(position, tonumber(arguments[1]))
+		local amount = PLUGIN:removePanel(position, radius)
 
 		-- Tell the player how many panels got removed.
 		return L("panelRemoved", client, amount)

--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -157,8 +157,11 @@ end
 
 nut.command.add("textadd", {
 	adminOnly = true,
-	syntax = "<string text> [number scale]",
-	onRun = function(client, arguments)
+	arguments = {
+		nut.type.string,
+		nut.type.tor(nut.type.number, nut.type.optional)
+	},
+	onRun = function(client, text, scale)
 		-- Get the position and angles of the text.
 		local trace = client:GetEyeTrace()
 		local position = trace.HitPos
@@ -167,7 +170,7 @@ nut.command.add("textadd", {
 		angles:RotateAroundAxis(angles:Forward(), 90)
 
 		-- Add the text.
-		PLUGIN:addText(position + angles:Up()*0.1, angles, arguments[1], tonumber(arguments[2]))
+		PLUGIN:addText(position + angles:Up()*0.1, angles, text, scale)
 
 		-- Tell the player the text was added.
 		return L("textAdded", client)
@@ -176,13 +179,13 @@ nut.command.add("textadd", {
 
 nut.command.add("textremove", {
 	adminOnly = true,
-	syntax = "[number radius]",
-	onRun = function(client, arguments)
+	arguments = nut.type.tor(nut.type.number, nut.type.optional),
+	onRun = function(client, radius)
 		-- Get the origin to remove text.
 		local trace = client:GetEyeTrace()
 		local position = trace.HitPos + trace.HitNormal*2
 		-- Remove the text(s) and get the amount removed.
-		local amount = PLUGIN:removeText(position, tonumber(arguments[1]))
+		local amount = PLUGIN:removeText(position, radius)
 
 		-- Tell the player how many texts got removed.
 		return L("textRemoved", client, amount)

--- a/plugins/act/sh_plugin.lua
+++ b/plugins/act/sh_plugin.lua
@@ -18,10 +18,12 @@ for k, v in pairs(PLUGIN.acts) do
 		end
 
 		if (multiple) then
-			data.syntax = "[number type]"
+			data.arguments = nut.type.tor(nut.type.number, nut.type.optional)
+		else
+			data.arguments = nut.type.optional
 		end
 
-		data.onRun = function(client, arguments)
+		data.onRun = function(client, actType)
 			if (client.nutSeqUntimed) then
 				client:setNetVar("actAng")
 				client:leaveSequence()
@@ -51,7 +53,7 @@ for k, v in pairs(PLUGIN.acts) do
 					local sequence
 
 					if (istable(info.sequence)) then
-						local index = math.Clamp(math.floor(tonumber(arguments[1]) or 1), 1, #info.sequence)
+						local index = math.Clamp(math.floor(actType or 1), 1, #info.sequence)
 
 						sequence = info.sequence[index]
 					else

--- a/plugins/area/sh_plugin.lua
+++ b/plugins/area/sh_plugin.lua
@@ -387,18 +387,11 @@ end
 
 nut.command.add("areaadd", {
 	adminOnly = true,
-	syntax = "<string name>",
-	onRun = function(client, arguments)
-		local name = table.concat(arguments, " ") or "Area"
-
+	arguments = nut.type.string,
+	onRun = function(client, name)
 		local pos = client:GetEyeTraceNoCursor().HitPos
 
 		if (!client:getNetVar("areaMin")) then
-			if (!name) then
-				nut.util.Notify(nut.lang.Get("missing_arg", 1), client)
-
-				return
-			end
 			netstream.Start(client, "displayPosition", pos)
 
 			client:setNetVar("areaMin", pos, client)
@@ -428,7 +421,7 @@ nut.command.add("areaadd", {
 
 nut.command.add("arearemove", {
 	adminOnly = true,
-	onRun = function(client, arguments)
+	onRun = function(client)
 		local areaID = client:getArea()
 
 		if (!areaID) then
@@ -452,9 +445,8 @@ nut.command.add("arearemove", {
 
 nut.command.add("areachange", {
 	adminOnly = true,
-	syntax = "<string name>",
-	onRun = function(client, arguments)
-		local name = table.concat(arguments, " ") or "Area"
+	arguments = nut.type.string,
+	onRun = function(client, name)
 		local areaID = client:getArea()
 
 		if (!areaID) then

--- a/plugins/attributes/sh_commands.lua
+++ b/plugins/attributes/sh_commands.lua
@@ -1,31 +1,17 @@
 nut.command.add("charsetattrib", {
 	adminOnly = true,
-	syntax = "<string charname> <string attribname> <number level>",
-	onRun = function(client, arguments)
-		local attribName = arguments[2]
-		if (!attribName) then
-			return L("invalidArg", client, 2)
-		end
+	arguments = {
+		nut.type.character,
+		nut.type.string,
+		nut.type.number
+	},
+	onRun = function(client, target, attribName, level)
+		for k, v in pairs(nut.attribs.list) do
+			if (nut.util.stringMatches(L(v.name, client), attribName) or nut.util.stringMatches(k, attribName)) then
+				target:setAttrib(k, math.abs(level))
+				client:notifyLocalized("attribSet", target:getName(), L(v.name, client), math.abs(level))
 
-		local attribNumber = arguments[3]
-		attribNumber = tonumber(attribNumber)
-		if (!attribNumber or !isnumber(attribNumber)) then
-			return L("invalidArg", client, 3)
-		end
-
-		local target = nut.command.findPlayer(client, arguments[1])
-
-		if (IsValid(target)) then
-			local char = target:getChar()
-			if (char) then
-				for k, v in pairs(nut.attribs.list) do
-					if (nut.util.stringMatches(L(v.name, client), attribName) or nut.util.stringMatches(k, attribName)) then
-						char:setAttrib(k, math.abs(attribNumber))
-						client:notifyLocalized("attribSet", target:Name(), L(v.name, client), math.abs(attribNumber))
-
-						return
-					end
-				end
+				return
 			end
 		end
 	end
@@ -33,32 +19,18 @@ nut.command.add("charsetattrib", {
 
 nut.command.add("charaddattrib", {
 	adminOnly = true,
-	syntax = "<string charname> <string attribname> <number level>",
-	onRun = function(client, arguments)
-		local attribName = arguments[2]
-		if (!attribName) then
-			return L("invalidArg", client, 2)
-		end
+	arguments = {
+		nut.type.character,
+		nut.type.string,
+		nut.type.number
+	},
+	onRun = function(client, target, attribName, level)
+		for k, v in pairs(nut.attribs.list) do
+			if (nut.util.stringMatches(L(v.name, client), attribName) or nut.util.stringMatches(k, attribName)) then
+				target:updateAttrib(k, math.abs(level))
+				client:notifyLocalized("attribUpdate", target:getName(), L(v.name, client), math.abs(level))
 
-		local attribNumber = arguments[3]
-		attribNumber = tonumber(attribNumber)
-		if (!attribNumber or !isnumber(attribNumber)) then
-			return L("invalidArg", client, 3)
-		end
-
-		local target = nut.command.findPlayer(client, arguments[1])
-
-		if (IsValid(target)) then
-			local char = target:getChar()
-			if (char) then
-				for k, v in pairs(nut.attribs.list) do
-					if (nut.util.stringMatches(L(v.name, client), attribName) or nut.util.stringMatches(k, attribName)) then
-						char:updateAttrib(k, math.abs(attribNumber))
-						client:notifyLocalized("attribUpdate", target:Name(), L(v.name, client), math.abs(attribNumber))
-
-						return
-					end
-				end
+				return
 			end
 		end
 	end

--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -1,373 +1,501 @@
+
 local PANEL = {}
-	local COLOR_FADED = Color(200, 200, 200, 100)
-	local COLOR_ACTIVE = color_white
 
-	function PANEL:Init()
-		local border = 32
-		local scrW, scrH = ScrW(), ScrH()
-		local w, h = scrW * 0.4, scrH * 0.375
+local TEXT_COLOR = Color(255, 255, 255, 200)
 
-		nut.gui.chat = self
+local function findInTable(tbl, haystack)
+	for _, needle in ipairs(tbl) do
+		local startPos, endPos, matched = string.find(haystack, needle)
 
-		self:SetSize(w, h)
-		self:SetPos(border, scrH - h - border)
-
-		self.active = false
-
-		self.tabs = self:Add("DPanel")
-		self.tabs:Dock(TOP)
-		self.tabs:SetTall(28)
-		self.tabs:DockPadding(4, 4, 4, 4)
-		self.tabs:SetVisible(false)
-		self.tabs.Paint = function(tabs, w, h)
-			surface.SetDrawColor(0, 0, 0, 100)
-			surface.DrawRect(0, 0, w, h)
-		end
-
-		self.arguments = {}
-
-		self.scroll = self:Add("DScrollPanel")
-		self.scroll:SetPos(4, 31)
-		self.scroll:SetSize(w - 8, h - 66)
-		self.scroll:GetVBar():SetWide(0)
-		self.scroll.PaintOver = function(this, w, h)
-			local entry = self.text
-
-			if (self.active and IsValid(entry)) then
-				local text = entry:GetText()
-
-				if (text:sub(1, 1) == "/") then
-					local arguments = self.arguments or {}
-					local command = string.PatternSafe(arguments[1] or ""):lower()
-
-					nut.util.drawBlur(this)
-
-					surface.SetDrawColor(0, 0, 0, 200)
-					surface.DrawRect(0, 0, w, h)
-
-					local i = 0
-					local color = nut.config.get("color")
-
-					for k, v in SortedPairs(nut.command.list) do
-						local k2 = "/"..k
-						local k = k:lower()
-
-						if (k2:lower():match(command)) then
-							local x = nut.util.drawText((v.realCommand and "/"..v.realCommand or k2).."  ", 4, i * 20, color)
-
-							if (k == command and v.syntax) then
-								local i2 = 0
-
-								for argument in v.syntax:gmatch("([%[<][%g_]+[%s][%g_]+[%]>])") do
-									i2 = i2 + 1
-									local color = COLOR_FADED
-
-									if (i2 == (#arguments - 1)) then
-										color = COLOR_ACTIVE
-									end
-
-									if (v.arguments and i2 == #v.arguments) then
-										if ((#arguments - 1) >= i2) then
-											color = COLOR_ACTIVE
-										end
-									end
-
-									x = x + nut.util.drawText(argument.."  ", x, i * 20, color)
-								end
-							end
-
-							i = i + 1
-						end
-					end
-				end
-			end
-		end
-
-		self.lastY = 0
-
-		self.list = {}
-		self.filtered = {}
-
-		chat.GetChatBoxPos = function()
-			return self:LocalToScreen(0, 0)
-		end
-
-		chat.GetChatBoxSize = function()
-			return self:GetSize()
-		end
-
-		local buttons = {}
-
-		for k, v in SortedPairsByMemberValue(nut.chat.classes, "filter") do
-			if (!buttons[v.filter]) then
-				self:addFilterButton(v.filter)
-				buttons[v.filter] = true
-			end
+		if (startPos) then
+			return startPos, endPos, matched
 		end
 	end
+end
 
-	function PANEL:Paint(w, h)
+function PANEL:Init()
+	nut.gui.chat = self
+
+	self.filterTabs = {
+		{name = "Main", filter = {"."}}
+	}
+
+	self:SetSize(ScrW() * 0.3, ScrH() * 0.35)
+	self:SetPos(ScrW() * 0.1, ScrH() - self:GetTall() - ScrH() * 0.1)
+
+	self.texts = {}
+	self.filterTbl = {}
+
+	self.frame = g_ContextMenu:Add("DFrame")
+	self.frame:SetSize(self:GetSize())
+	self.frame:SetPos(self:GetPos())
+	self.frame:SetTitle("Chatbox")
+	self.frame:ShowCloseButton(false)
+	self.frame.OnCursorMoved = function(this, cursorX, cursorY)
+		if (this.Dragging) then
+			self:SetPos(this:GetPos())
+		end
+	end
+	hook.Add("OnContextMenuOpen", self.frame, function(this)
+		this:SetMouseInputEnabled(true)
+	end)
+
+	surface.SetFont("nutToolTipText")
+
+	self.headerBar = self:Add("Panel")
+	self.headerBar:Dock(TOP)
+	self.headerBar:SetTall(select(2, surface.GetTextSize("W")))
+	self.headerBar.Paint = function(this, width, height)
 		if (self.active) then
-			nut.util.drawBlur(self, 10)
-
-			surface.SetDrawColor(250, 250, 250, 2)
-			surface.DrawRect(0, 0, w, h)
-
-			surface.SetDrawColor(0, 0, 0, 240)
-			surface.DrawOutlinedRect(0, 0, w, h)
+			for _, v in ipairs(this:GetChildren()) do
+				v:PaintManual()
+			end
 		end
 	end
 
-	local TEXT_COLOR = Color(255, 255, 255, 200)
+	self.tabsContainer = self.headerBar:Add("DHorizontalScroller")
+	self.tabsContainer:Dock(LEFT)
+	self.tabsContainer.btnLeft:SetPaintedManually(true)
+	self.tabsContainer.btnRight:SetPaintedManually(true)
 
-	function PANEL:setActive(state)
-		self.active = state
+	self.newTab = self.headerBar:Add("DButton")
+	self.newTab:Dock(LEFT)
+	self.newTab:SetFont("nutToolTipText")
+	self.newTab:SetText("+")
+	self.newTab:SizeToContents()
+	self.newTab:SetPaintedManually(true)
+	self.newTab.DoClick = function()
+		if (self.tabCustomize) then
+			self.tabCustomize:Remove()
+		end
 
-		if (state) then
-			self.entry = self:Add("EditablePanel")
-			self.entry:SetPos(self.x + 4, self.y + self:GetTall() - 32)
-			self.entry:SetWide(self:GetWide() - 8)
-			--self.entry.Paint = function(this, w, h)
-			--end
-			self.entry.OnRemove = function()
-				hook.Run("FinishChat")
+		self.tabCustomize = vgui.Create("nutChatboxTabCustomize")
+	end
+	self.newTab.Paint = function(this, width, height)
+		surface.SetDrawColor(nut.config.get("color"))
+		surface.SetMaterial(nut.util.getMaterial("vgui/gradient-d"))
+		surface.DrawTexturedRect(0, 0, width, height * (this:IsHovered() and 1 or 2))
+	end
+
+	self.textContainer = self:Add("DScrollPanel")
+	self.textContainer:Dock(FILL)
+	self.textContainer.pnlCanvas:DockPadding(4, 4, 4, 4)
+	self.textContainer.VBar:SetWide(0)
+	self.textContainer.Paint = function(this, width, height)
+		if (self.active) then
+			nut.util.drawBlur(this)
+
+			local colorR, colorG, colorB = nut.config.get("colorBackground"):Unpack()
+
+			surface.SetDrawColor(colorR, colorG, colorB, 32)
+
+			surface.SetMaterial(nut.util.getMaterial("vgui/gradient-u"))
+			surface.DrawTexturedRect(0, 0, width, height)
+
+			surface.SetMaterial(nut.util.getMaterial("vgui/gradient-l"))
+			surface.DrawTexturedRect(0, 0, width, height)
+
+			surface.SetDrawColor(0, 0, 0, 128)
+			surface.DrawRect(0, 0, width, height)
+
+			surface.SetDrawColor(nut.config.get("color"))
+			surface.SetMaterial(nut.util.getMaterial("vgui/gradient-l"))
+			surface.DrawTexturedRect(0, 0, width, 2)
+		end
+	end
+
+	self.commandList = self:Add("DScrollPanel")
+	self.commandList:Dock(FILL)
+	self.commandList:DockMargin(0, 2, 0, 0)
+	self.commandList.pnlCanvas:DockPadding(4, 4, 4, 4)
+	self.commandList.VBar:SetWide(0)
+	self.commandList.Paint = function(this, width, height)
+		if (!self.active or !self.arguments or self.activeCommand) then return end
+
+		local commandsVisible = 0
+
+		for k, v in ipairs(this:GetCanvas():GetChildren()) do
+			if (v.visible) then
+				commandsVisible = commandsVisible + 1
 			end
-			self.entry:SetTall(28)
+		end
 
-			nut.chat.history = nut.chat.history or {}
+		if (commandsVisible > 0) then
+			nut.util.drawBlur(this)
 
-			self.text = self.entry:Add("DTextEntry")
-			self.text:Dock(FILL)
-			self.text.History = nut.chat.history
-			self.text:SetHistoryEnabled(true)
-			self.text:DockMargin(0, 0, 0, 0)
-			self.text:SetFont("nutChatFont")
-			self.text.OnEnter = function(this)
-				local text = this:GetText()
+			surface.SetDrawColor(0, 0, 0, 192)
+			surface.DrawRect(0, 0, width, height)
 
-				this:Remove()
+			for k, v in pairs(this:GetCanvas():GetChildren()) do
+				v:PaintManual()
+			end
+		end
+	end
 
-				self.tabs:SetVisible(false)
-				self.active = false
-				self.entry:Remove()
+	for k, v in SortedPairs(nut.command.list) do
+		if (v.onCheckAccess and !v.onCheckAccess(LocalPlayer())) then
+			continue
+		else
+			local b = self.commandList:Add("DButton")
+			b:Dock(TOP)
+			b:DockMargin(0, 0, 0, 4)
+			b:SetText("")
+			b:SetPaintedManually(true)
+			b.command = k
+			b.visible = true
+			b.DoClick = function()
+				self.entry:SetText("/" .. k)
+				self.entry:SetCaretPos(string.len(self.entry:GetText()))
+			end
+			b.Paint = function(this, width, height)
+				surface.SetDrawColor(this:IsHovered() and nut.config.get("color") or color_transparent)
+				surface.SetMaterial(nut.util.getMaterial("vgui/gradient-l"))
+				surface.DrawTexturedRect(0, 0, width, height)
+			end
 
-				if (text:find("%S")) then
-					if (!(nut.chat.lastLine or ""):find(text, 1, true)) then
-						nut.chat.history[#nut.chat.history + 1] = text
-						nut.chat.lastLine = text
+			local c = b:Add("DLabel")
+			c:Dock(LEFT)
+			c:DockMargin(0, 0, 4, 0)
+			c:SetFont("nutToolTipText")
+			c:SetText("/" .. (v.realCommand or k))
+			c:SizeToContents()
+			c:SetContentAlignment(4)
+			c:SetPaintBackground(false)
+
+			local syntax = b:Add("DLabel")
+			syntax:Dock(LEFT)
+			syntax:SetFont("nutToolTipText")
+			syntax:SetText(v.syntax)
+			syntax:SizeToContents()
+			syntax:SetContentAlignment(4)
+			syntax:SetPaintBackground(false)
+		end
+	end
+
+	surface.SetFont("nutChatFont")
+
+	self.entryContainer = self:Add("Panel")
+	self.entryContainer:Dock(BOTTOM)
+	self.entryContainer:DockPadding(4, 8, 4, 8)
+	self.entryContainer:SetTall(select(2, surface.GetTextSize("W")) + 16)
+	self.entryContainer.Paint = function(this, width, height)
+		if (self.active) then
+			surface.SetDrawColor(0, 0, 0, 255)
+			surface.DrawRect(0, 0, width, height)
+
+			surface.SetDrawColor(32, 32, 32, 128)
+			surface.SetMaterial(nut.util.getMaterial("vgui/gradient-u"))
+			surface.DrawTexturedRect(0, 0, width, height * 1.5)
+		end
+	end
+	hook.Add("LoadFonts", self.entryContainer, function(this)
+		surface.SetFont("nutChatFont")
+		this:SetTall(select(2, surface.GetTextSize("W")) + 16)
+	end)
+
+	surface.SetFont("nutToolTipText")
+
+	self.commandContainer = self:Add("Panel")
+	self.commandContainer:DockPadding(4, 8, 4, 8)
+	self.commandContainer:SetSize(self:GetWide(), select(2, surface.GetTextSize("W")) + 16)
+	self.commandContainer:SetMouseInputEnabled(false)
+
+	self:InvalidateLayout(true)
+	local x, y = self.entryContainer:GetPos()
+	self.commandContainer:SetPos(x, y - self.commandContainer:GetTall())
+
+	self.commandContainer.Paint = function(this, width, height)
+		if (!self.active) then return end
+
+		if (self.activeCommand) then
+			surface.SetDrawColor(0, 0, 0, 255)
+			surface.DrawRect(0, 0, width, height)
+
+			for k, v in pairs(this:GetChildren()) do
+				v:PaintManual()
+			end
+		end
+	end
+	hook.Add("LoadFonts", self.commandContainer, function(this)
+		surface.SetFont("nutToolTipText")
+		this:SetTall(select(2, surface.GetTextSize("W")) + 16)
+
+		self:InvalidateLayout(true)
+		local x, y = self.entryContainer:GetPos()
+		this:SetPos(x, y - this:GetTall())
+	end)
+
+	self.commandName = self.commandContainer:Add("DLabel")
+	self.commandName:Dock(LEFT)
+	self.commandName:DockMargin(0, 0, 4, 0)
+	self.commandName:SetFont("nutToolTipText")
+	self.commandName:SetText("")
+	self.commandName:SetPaintedManually(true)
+
+	self.commandSyntax = self.commandContainer:Add("DLabel")
+	self.commandSyntax:Dock(LEFT)
+	self.commandSyntax:SetFont("nutToolTipText")
+	self.commandSyntax:SetText("")
+	self.commandSyntax:SetPaintedManually(true)
+
+	self.entry = self.entryContainer:Add("DTextEntry")
+	self.entry:Dock(FILL)
+	self.entry:SetFont("nutChatFont")
+	self.entry:SetAllowNonAsciiCharacters(true)
+	self.entry:DockMargin(0, 0, 0, 0)
+	self.entry.OnEnter = function(this)
+		local text = this:GetText()
+
+		self:setActive(false)
+		self.arguments = nil
+
+		if (text:find("%S")) then
+			netstream.Start("msg", text)
+		end
+	end
+	self.entry.OnTextChanged = function(this)
+		local text = this:GetText()
+
+		hook.Run("ChatTextChanged", text)
+
+		if (text:sub(1, 1) == "/") then
+			self.arguments = nut.command.extractArgs(text:sub(2))
+
+			for _, v in ipairs(self.commandList:GetCanvas():GetChildren()) do
+				if (!v.command:find(text:sub(2))) then
+					v.visible = false
+					v.oldHeight = v.oldHeight or v:GetTall()
+					v:SizeTo(-1, 0, 0.1, nil, nil, function(anim, panel)
+						panel:DockMargin(0, 0, 0, 0)
+					end)
+				else
+					v.visible = true
+					v:SizeTo(-1, v.oldHeight or -1, 0.1, nil, nil, function(anim, panel)
+						panel:DockMargin(0, 0, 0, 4)
+					end)
+				end
+			end
+
+			local command = text:match("^/(%S+)")
+
+			if (command and command:sub(1, 1) == "/") then
+				command = "/"
+			end
+
+			self.activeCommand = nut.command.list[command]
+
+			if (self.activeCommand) then
+				self.commandName:SetText(self.activeCommand.realCommand or command)
+				self.commandName:SizeToContents()
+
+				self.commandSyntax:SetText(self.activeCommand.syntax)
+				self.commandSyntax:SizeToContents()
+			end
+		else
+			self.activeCommand = nil
+			self.arguments = nil
+		end
+	end
+	self.entry.OnFocusChanged = function(this, gained)
+		if (!gained) then
+			this:RequestFocus()
+		end
+	end
+	self.entry.Paint = function(this, width, height)
+		this:DrawTextEntryText(TEXT_COLOR, nut.config.get("color"), TEXT_COLOR)
+	end
+
+	self:rebuildTabs()
+	self:setActive(false)
+end
+
+function PANEL:Remove()
+	self.frame:Remove()
+
+	baseclass.Get("EditablePanel").Remove(self)
+end
+
+function PANEL:Think()
+	if (self.active) then
+		if (gui.IsGameUIVisible()) then
+			self:setActive(false)
+		end
+	end
+end
+
+function PANEL:rebuildTabs()
+	self.tabsContainer:GetCanvas():Clear()
+
+	local totalWidth = 0
+
+	for k, v in ipairs(self.filterTabs) do
+		local b = vgui.Create("DButton", self.tabsContainer)
+		self.tabsContainer:AddPanel(b)
+		b:Dock(LEFT)
+		b:SetFont("nutToolTipText")
+		b:SetText(v.name)
+		b:SizeToContents()
+		totalWidth = totalWidth + b:GetWide()
+		b:SetPaintedManually(true)
+		b.DoClick = function(this)
+			if (this.state != true) then
+				this.state = true
+				self.filterTbl = v.filter
+				self.selectedFilter = k
+
+				for _, v in ipairs(self.tabsContainer:GetCanvas():GetChildren()) do
+					if (v != this) then
+						v.state = false
 					end
-
-					netstream.Start("msg", text)
 				end
-			end
-			self.text:SetAllowNonAsciiCharacters(true)
-			self.text.Paint = function(this, w, h)
-				surface.SetDrawColor(0, 0, 0, 100)
-				surface.DrawRect(0, 0, w, h)
 
-				surface.SetDrawColor(0, 0, 0, 200)
-				surface.DrawOutlinedRect(0, 0, w, h)
+				local lastText
 
-				this:DrawTextEntryText(TEXT_COLOR, nut.config.get("color"), TEXT_COLOR)
-			end
-			self.text.OnTextChanged = function(this)
-				local text = this:GetText()
-
-				hook.Run("ChatTextChanged", text)
-
-				if (text:sub(1, 1) == "/") then
-					self.arguments = nut.command.extractArgs(text:sub(2))
-				end
-			end
-
-			self.entry:MakePopup()
-			self.text:RequestFocus()
-			self.tabs:SetVisible(true)
-
-			hook.Run("StartChat")
-		end
-	end
-
-	local function OnDrawText(text, font, x, y, color, alignX, alignY, alpha)
-		alpha = alpha or 255
-
-		surface.SetTextPos(x+1, y+1)
-		surface.SetTextColor(0, 0, 0, alpha)
-		surface.SetFont(font)
-		surface.DrawText(text)
-
-		surface.SetTextPos(x, y)
-		surface.SetTextColor(color.r, color.g, color.b, alpha)
-		surface.SetFont(font)
-		surface.DrawText(text)
-		--draw.SimpleTextOutlined(text, font, x, y, ColorAlpha(color, alpha), 0, alignY, 1, ColorAlpha(color_black, alpha * 0.6))
-	end
-
-	local function PaintFilterButton(this, w, h)
-		if (this.active) then
-			surface.SetDrawColor(40, 40, 40)
-		else
-			local alpha = 120 + math.cos(RealTime() * 5) * 10
-
-			surface.SetDrawColor(ColorAlpha(nut.config.get("color"), alpha))
-		end
-
-		surface.DrawRect(0, 0, w, h)
-
-		surface.SetDrawColor(0, 0, 0, 200)
-		surface.DrawOutlinedRect(0, 0, w, h)
-	end
-
-	local color_blackTransparent = Color(0,0,0,200)
-
-	function PANEL:addFilterButton(filter)
-		local name = L(filter)
-
-		local tab = self.tabs:Add("DButton")
-		tab:SetFont("nutChatFont")
-		tab:SetText(name:upper())
-		tab:SizeToContents()
-		tab:DockMargin(0, 0, 3, 0)
-		tab:SetWide(tab:GetWide() + 32)
-		tab:Dock(LEFT)
-		tab:SetTextColor(nut.config.get("colorText", color_white))
-		tab:SetExpensiveShadow(1, color_blackTransparent)
-		tab.Paint = PaintFilterButton
-		tab.DoClick = function(this)
-			this.active = !this.active
-
-			local filters = NUT_CVAR_CHATFILTER:GetString():lower()
-
-			if (filters == "none") then
-				filters = ""
-			end
-
-			if (this.active) then
-				filters = filters..filter..","
-			else
-				filters = filters:gsub(filter.."[,]", "")
-
-				if (!filters:find("%S")) then
-					filters = "none"
-				end
-			end
-
-			self:setFilter(filter, this.active)
-			RunConsoleCommand("nut_chatfilter", filters)
-		end
-
-		if (NUT_CVAR_CHATFILTER:GetString():lower():find(filter)) then
-			tab.active = true
-		end
-	end
-
-	function PANEL:addText(...)
-		local text = "<font=nutChatFont>"
-
-		if (CHAT_CLASS) then
-			text = "<font="..(CHAT_CLASS.font or "nutChatFont")..">"
-		end
-
-		text = hook.Run("ChatAddText", text, ...) or text
-
-		for k, v in ipairs({...}) do
-			if (type(v) == "IMaterial") then
-				local ttx = v:GetName()
-				text = text.."<img="..ttx..","..v:Width().."x"..v:Height()..">"
-			elseif (IsColor(v) and v.r and v.g and v.b) then
-				text = text.."<color="..v.r..","..v.g..","..v.b..">"
-			elseif (type(v) == "Player") then
-				local color = team.GetColor(v:Team())
-
-				text = text.."<color="..color.r..","..color.g..","..color.b..">"..v:Name():gsub("<", "&lt;"):gsub(">", "&gt;"):gsub("#", "\226\128\139#")
-			else
-				text = text..tostring(v):gsub("<", "&lt;"):gsub(">", "&gt;")
-				text = text:gsub("%b**", function(value)
-					local inner = value:sub(2, -2)
-
-					if (inner:find("%S")) then
-						return "<font=nutChatFontItalics>"..value:sub(2, -2).."</font>"
+				for _, textPanel in ipairs(self.texts) do
+					if (textPanel.chatClass and textPanel.chatClass.filter) then
+						if (!findInTable(v.filter, textPanel.chatClass.filter)) then
+							textPanel:SetVisible(false)
+						else
+							textPanel:SetVisible(true)
+							lastText = textPanel
+						end
+					else
+						lastText = textPanel
 					end
-				end)
+				end
+
+				self.textContainer:GetCanvas():InvalidateLayout(true)
+
+				if (IsValid(lastText)) then
+					self.textContainer:InvalidateLayout(true)
+
+					local x, y = self.textContainer:GetCanvas():GetChildPosition(lastText)
+					local w, h = lastText:GetSize()
+
+					y = y + h * 0.5
+					y = y - self.textContainer:GetTall() * 0.5
+
+					self.textContainer.VBar:SetScroll(y)
+				end
 			end
 		end
+		b.DoRightClick = function(this)
+			local menu = DermaMenu()
 
-		text = text.."</font>"
+			local customizeButton = menu:AddOption("Customize", function()
+				vgui.Create("nutChatboxTabCustomize"):setFilter(k, v)
+			end)
+			customizeButton:SetIcon("icon16/pencil.png")	
 
-		local panel = self.scroll:Add("nutMarkupPanel")
-		panel:SetWide(self:GetWide() - 8)
-		panel:setMarkup(text, OnDrawText)
-		panel.start = CurTime() + 15
-		panel.finish = panel.start + 20
-		panel.Think = function(this)
-			if (self.active) then
-				this:SetAlpha(255)
+			menu:AddSpacer()
+
+			local deleteButton = menu:AddOption("Delete", function()
+				table.remove(self.filterTabs, k)
+
+				if (self.selectedFilter == k) then
+					self.selectedFilter = nil
+					self.filterTbl = {}
+				end
+
+				self:rebuildTabs()
+			end)
+			deleteButton:SetIcon("icon16/cross.png")
+
+			menu:Open()
+		end
+		b.Paint = function(this, width, height)
+			surface.SetDrawColor(nut.config.get("color"))
+
+			if (this.state) then
+				surface.DrawRect(0, 0, width, height)
 			else
-				this:SetAlpha((1 - math.TimeFraction(this.start, this.finish, CurTime())) * 255)
+				surface.SetMaterial(nut.util.getMaterial("vgui/gradient-d"))
+				surface.DrawTexturedRect(0, 0, width, height * (this:IsHovered() and 1 or 2))
 			end
 		end
 
-		self.list[#self.list + 1] = panel
+		if (#self.filterTbl == 0 or self.selectedFilter == k) then
+			b:DoClick()
+		end
+	end
 
-		local class = CHAT_CLASS and CHAT_CLASS.filter and CHAT_CLASS.filter:lower() or "ic"
+	self.tabsContainer:SetWide(totalWidth)
+end
 
-		if (NUT_CVAR_CHATFILTER:GetString():lower():find(class)) then
-			self.filtered[panel] = class
-			panel:SetVisible(false)
+function PANEL:setActive(active)
+	if (g_ContextMenu:IsVisible()) then return end
+
+	self.active = active
+
+	if (active) then
+		self:MakePopup()
+		self.entry:RequestFocus()
+	end
+
+	self:SetKeyboardInputEnabled(active)
+	self:SetMouseInputEnabled(active)
+
+	self.entry:SetVisible(active)
+	self.entry:SetText("")
+	self.entry:OnTextChanged()
+end
+
+function PANEL:addText(...)
+	local text = "<font=nutChatFont>"
+
+	if (CHAT_CLASS) then
+		text = "<font="..(CHAT_CLASS.font or "nutChatFont")..">"
+	end
+
+	text = hook.Run("ChatAddText", text, ...) or text
+
+	for k, v in ipairs({...}) do
+		if (type(v) == "IMaterial") then
+			local ttx = v:GetName()
+			text = text.."<img="..ttx..","..v:Width().."x"..v:Height()..">"
+		elseif (IsColor(v) and v.r and v.g and v.b) then
+			text = text.."<color="..v.r..","..v.g..","..v.b..">"
+		elseif (type(v) == "Player") then
+			local color = team.GetColor(v:Team())
+
+			text = text.."<color="..color.r..","..color.g..","..color.b..">"..v:Name():gsub("<", "&lt;"):gsub(">", "&gt;"):gsub("#", "\226\128\139#")
 		else
-			panel:SetPos(0, self.lastY)
+			text = text..tostring(v):gsub("<", "&lt;"):gsub(">", "&gt;")
+			text = text:gsub("%b**", function(value)
+				local inner = value:sub(2, -2)
 
-			self.lastY = self.lastY + panel:GetTall()
-			self.scroll:ScrollToChild(panel)
+				if (inner:find("%S")) then
+					return "<font=nutChatFontItalics>"..value:sub(2, -2).."</font>"
+				end
+			end)
 		end
-
-		panel.filter = class
-
-		return panel:IsVisible()
 	end
 
-	function PANEL:setFilter(filter, state)
-		if (state) then
-			for k, v in ipairs(self.list) do
-				if (v.filter == filter) then
-					v:SetVisible(false)
-					self.filtered[v] = filter
-				end
-			end
+	text = text.."</font>"
+
+	local panel = self.textContainer:Add("nutMarkupPanel")
+	panel:Dock(TOP)
+	panel:setMarkup(text, OnDrawText)
+	panel.chatClass = CHAT_CLASS
+	panel.start = CurTime() + 15
+	panel.finish = panel.start + 20
+	panel.Think = function(this)
+		if (self.active) then
+			this:SetAlpha(255)
 		else
-			for k, v in pairs(self.filtered) do
-				if (v == filter) then
-					k:SetVisible(true)
-					self.filtered[k] = nil
-				end
-			end
-		end
-
-		self.lastY = 0
-
-		local lastChild
-
-		for k, v in ipairs(self.list) do
-			if (v:IsVisible()) then
-				v:SetPos(0, self.lastY)
-				self.lastY = self.lastY + v:GetTall() + 2
-				lastChild = v
-			end
-		end
-
-		if (IsValid(lastChild)) then
-			self.scroll:ScrollToChild(lastChild)
+			this:SetAlpha((1 - math.TimeFraction(this.start, this.finish, CurTime())) * 255)
 		end
 	end
 
-	function PANEL:Think()
-		if (gui.IsGameUIVisible() and self.active) then
-			self.tabs:SetVisible(false)
-			self.active = false
+	self.textContainer:GetCanvas():InvalidateLayout(true)
 
-			if (IsValid(self.entry)) then
-				self.entry:Remove()
-			end
-		end
+	if (CHAT_CLASS and CHAT_CLASS.filter and !findInTable(self.filterTbl, CHAT_CLASS.filter)) then
+		panel:SetVisible(false)
+	else
+		self.textContainer:ScrollToChild(panel)
 	end
-vgui.Register("nutChatBox", PANEL, "DPanel")
+
+	table.insert(self.texts, panel)
+end
+
+vgui.Register("nutChatBox", PANEL, "EditablePanel")

--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -58,12 +58,18 @@ local PANEL = {}
 							if (k == command and v.syntax) then
 								local i2 = 0
 
-								for argument in v.syntax:gmatch("([%[<][%w_]+[%s][%w_]+[%]>])") do
+								for argument in v.syntax:gmatch("([%[<][%g_]+[%s][%g_]+[%]>])") do
 									i2 = i2 + 1
 									local color = COLOR_FADED
 
 									if (i2 == (#arguments - 1)) then
 										color = COLOR_ACTIVE
+									end
+
+									if (v.arguments and i2 == #v.arguments) then
+										if ((#arguments - 1) >= i2) then
+											color = COLOR_ACTIVE
+										end
 									end
 
 									x = x + nut.util.drawText(argument.."  ", x, i * 20, color)

--- a/plugins/chatbox/derma/cl_markup.lua
+++ b/plugins/chatbox/derma/cl_markup.lua
@@ -1,15 +1,28 @@
+
 local PANEL = {}
-	function PANEL:Init()
-		self:SetPaintBackground(false)
-	end
 
-	function PANEL:setMarkup(text, onDrawText)
-		local object = nut.markup.parse(text, self:GetWide())
-		object.onDrawText = onDrawText
-
-		self:SetTall(object:getHeight())
-		self.Paint = function(this, w, h)
-			object:draw(0, 0)
+function PANEL:Init()
+	hook.Add("LoadFonts", self, function(this)
+		if (this.text) then
+			this:setMarkup(this.text, this.onDrawText)
 		end
+	end)
+end
+
+function PANEL:setMarkup(text, onDrawText)
+	self:InvalidateParent(true)
+	self:InvalidateLayout(true)
+
+	self.text = text
+	self.onDrawText = onDrawText
+
+	local object = nut.markup.parse(text, self:GetWide())
+	object.onDrawText = onDrawText
+
+	self:SetTall(object:getHeight())
+	self.Paint = function(this, width, height)
+		object:draw(0, 0)
 	end
+end
+
 vgui.Register("nutMarkupPanel", PANEL, "DPanel")

--- a/plugins/chatbox/derma/cl_tab_customize.lua
+++ b/plugins/chatbox/derma/cl_tab_customize.lua
@@ -1,0 +1,158 @@
+
+local PANEL = {}
+
+local TEXT_COLOR = Color(255, 255, 255, 200)
+
+function PANEL:Init()
+	self:SetSize(ScrW() * 0.15, ScrH() * 0.3)
+	self:Center()
+
+	self:SetTitle("Tab Customize")
+	self:MakePopup()
+
+	surface.SetFont("nutBigFont")
+
+	self.nameEntry = self:Add("DTextEntry")
+	self.nameEntry:Dock(TOP)
+	self.nameEntry:DockMargin(0, 0, 0, 4)
+	self.nameEntry:SetFont("nutBigFont")
+	self.nameEntry:SetTall(select(2, surface.GetTextSize("W")))
+	self.nameEntry:SetPlaceholderText("Tab Name")
+	self.nameEntry:SetPaintBackground(false)
+	self.nameEntry:SetTextColor(TEXT_COLOR)
+	self.nameEntry:SetHighlightColor(nut.config.get("color"))
+	self.nameEntry:SetCursorColor(TEXT_COLOR)
+	self.nameEntry.Paint = function(this, width, height)
+		surface.SetDrawColor(0, 0, 0, 127)
+		surface.DrawRect(0, 0, width, height)
+
+		derma.SkinHook("Paint", "TextEntry", this, width, height)
+	end
+
+	surface.SetFont("nutMediumLightFont")
+
+	self.filterEntry = self:Add("DTextEntry")
+	self.filterEntry:Dock(TOP)
+	self.filterEntry:DockMargin(0, 0, 0, 4)
+	self.filterEntry:SetFont("nutMediumLightFont")
+	self.filterEntry:SetTall(select(2, surface.GetTextSize("W")))
+	self.filterEntry:SetPlaceholderText("Filter")
+	self.filterEntry:SetPaintBackground(false)
+	self.filterEntry:SetTextColor(TEXT_COLOR)
+	self.filterEntry:SetHighlightColor(nut.config.get("color"))
+	self.filterEntry:SetCursorColor(TEXT_COLOR)
+	self.filterEntry.OnTextChanged = function(this)
+		local text = this:GetText()
+
+		for k, v in pairs(self.scroll:GetCanvas():GetChildren()) do
+			if (!string.find(v.filter, text)) then
+				v.oldHeight = v.oldHeight or v:GetTall()
+				v:SizeTo(-1, 0, 0.1, nil, nil, function(anim, panel)
+					panel:DockMargin(0, 0, 0, 0)
+				end)
+			else
+				v:SizeTo(-1, v.oldHeight or -1, 0.1, nil, nil, function(anim, panel)
+					panel:DockMargin(0, 0, 0, 4)
+				end)
+			end
+		end
+	end
+	self.filterEntry.Paint = function(this, width, height)
+		surface.SetDrawColor(0, 0, 0, 127)
+		surface.DrawRect(0, 0, width, height)
+
+		derma.SkinHook("Paint", "TextEntry", this, width, height)
+	end
+
+	self.scroll = self:Add("DScrollPanel")
+	self.scroll:Dock(FILL)
+
+	self.filter = {}
+
+	for _, v in pairs(nut.chat.classes) do
+		if (v.filter) then
+			self.filter[v.filter] = true
+		end
+	end
+
+	self.modified = false
+
+	for k in pairs(self.filter) do
+		local b = self.scroll:Add("DButton")
+		b:Dock(TOP)
+		b:DockMargin(0, 0, 0, 4)
+		b:SetText(k)
+		b.filter = k
+		b.DoClick = function(this)
+			self.modified = true
+			self.filter[k] = !self.filter[k]
+		end
+		b.Paint = function(this, width, height)
+			if (self.filter[k] or this:IsHovered()) then
+				surface.SetDrawColor(this:IsHovered() and (self.filter[k] and Color(255, 0, 0) or Color(0, 255, 0)) or nut.config.get("color"))
+				surface.SetMaterial(nut.util.getMaterial("vgui/gradient-l"))
+				surface.DrawTexturedRect(0, 0, width, height)
+			end
+		end
+	end
+
+	self.save = self:Add("DButton")
+	self.save:Dock(BOTTOM)
+	self.save:SetText("Save Tab")
+	self.save.DoClick = function(this)
+		if (self.nameEntry:GetValue():find("%S")) then
+			self:Remove()
+
+			local filterTbl = {}
+
+			if (!self.modified) then
+				table.insert(filterTbl, ".")
+			else
+				for k, v in pairs(self.filter) do
+					if (v) then
+						table.insert(filterTbl, k)
+					end
+				end
+			end
+
+			local index = self.index or #nut.gui.chat.filterTabs + 1
+
+			nut.gui.chat.filterTabs[index] = {
+				name = self.nameEntry:GetValue(),
+				filter = filterTbl
+			}
+			nut.gui.chat:rebuildTabs()
+		else
+			nut.util.notify("invalid name")
+		end
+	end
+	self.save.Paint = function(this, width, height)
+		surface.SetDrawColor(nut.config.get("color"))
+		surface.SetMaterial(nut.util.getMaterial("vgui/gradient-l"))
+		surface.DrawTexturedRect(-width * (this:IsHovered() and 0 or 1), 0, width * (this:IsHovered() and 1 or 2), height)
+	end
+end
+
+function PANEL:setFilter(index, filterData)
+	self.nameEntry:SetText(filterData.name)
+	self.index = index
+
+	local filterTbl = filterData.filter
+	if (filterTbl[1] == ".") then
+		return
+	end
+
+	self.modified = true
+
+	local filter = {}
+
+	for _, v in pairs(filterTbl) do
+		filter[v] = true
+	end
+
+	for k in pairs(self.filter) do
+		self.filter[k] = filter[k] or false
+	end
+end
+
+vgui.Register("nutChatboxTabCustomize", PANEL, "DFrame")

--- a/plugins/chatbox/sh_plugin.lua
+++ b/plugins/chatbox/sh_plugin.lua
@@ -64,8 +64,9 @@ if (CLIENT) then
 	concommand.Add("fixchatplz", function()
 		if (IsValid(PLUGIN.panel)) then
 			PLUGIN.panel:Remove()
-			PLUGIN:createChat()
 		end
+
+		PLUGIN:createChat()
 	end)
 else
 	netstream.Hook("msg", function(client, text)

--- a/plugins/f1menu/derma/cl_helps.lua
+++ b/plugins/f1menu/derma/cl_helps.lua
@@ -114,7 +114,11 @@ hook.Add("BuildHelpMenu", "nutBasicHelp", function(tabs)
 			end
 
 			if (allowed) then
-				body = body.."<h2>/"..k.."</h2><strong>Syntax:</strong> <em>"..v.syntax.."</em><br /><br />"
+				local syntax = v.syntax
+				syntax = string.gsub(syntax, "<", "&lt")
+				syntax = string.gsub(syntax, ">", "&gt")
+
+				body = body.."<h2>/"..k.."</h2><strong>Syntax:</strong> <em>"..syntax.."</em><br /><br />"
 			end
 		end
 

--- a/plugins/mapscene.lua
+++ b/plugins/mapscene.lua
@@ -166,12 +166,12 @@ local PLUGIN = PLUGIN
 
 nut.command.add("mapsceneadd", {
 	adminOnly = true,
-	syntax = "[bool isPair]",
-	onRun = function(client, arguments)
+	arguments = nut.type.tor(nut.type.bool, nut.type.optional),
+	onRun = function(client, isPair)
 		local position, angles = client:EyePos(), client:EyeAngles()
 
 		-- This scene is in a pair for moving scenes.
-		if (util.tobool(arguments[1]) and !client.nutScnPair) then
+		if (isPair == true and !client.nutScnPair) then
 			client.nutScnPair = {position, angles}
 
 			return L("mapRepeat", client)
@@ -190,9 +190,9 @@ nut.command.add("mapsceneadd", {
 
 nut.command.add("mapsceneremove", {
 	adminOnly = true,
-	syntax = "[number radius]",
-	onRun = function(client, arguments)
-		local radius = tonumber(arguments[1]) or 280
+	arguments = nut.type.tor(nut.type.number, nut.type.optional),
+	onRun = function(client, radius)
+		radius = radius or 280
 		local position = client:GetPos()
 		local i = 0
 

--- a/plugins/sam_commands.lua
+++ b/plugins/sam_commands.lua
@@ -8,12 +8,12 @@ local color_red = Color(255, 0, 0)
 local color_green = Color(0, 255, 0)
 
 nut.command.add("asay", {
-    syntax = "<string message>",
+    arguments = nut.type.string,
     onCheckAccess = function(client)
         return client:IsAdmin() or sam.config.get_updated("Reports", true).value
     end,
-    onRun = function(client, arguments)
-        local text = table.concat(arguments, " ")
+    onRun = function(client, message)
+        local text = message
 
         if (text:find("%S")) then
             if client:IsAdmin() then

--- a/plugins/spawns.lua
+++ b/plugins/spawns.lua
@@ -49,78 +49,44 @@ end
 
 nut.command.add("spawnadd", {
 	adminOnly = true,
-	syntax = "<string faction> [string class]",
-	onRun = function(client, arguments)
-		local faction
-		local name = arguments[1]
-		local class = table.concat(arguments, " ", 2)
-		local info
-		local info2
+	arguments = {
+		nut.type.faction,
+		nut.type.tor(nut.type.class, nut.type.optional)
+	},
+	onRun = function(client, factionName, className)
+		local info = factionName
+		local info2 = className
 
-		if (name) then
-			info = nut.faction.indices[name:lower()]
+		local faction = info.uniqueID
+		local class = ""
 
-			if (!info) then
-				for k, v in ipairs(nut.faction.indices) do
-					if (nut.util.stringMatches(v.uniqueID, name) or nut.util.stringMatches(L(v.name, client), name)) then
-						faction = v.uniqueID
-						info = v
-
-						break
-					end
-				end
-			end
-
-			if (info) then
-				if (class and class ~= "") then
-					local found = false
-
-					for k, v in ipairs(nut.class.list) do
-						if (v.faction == info.index and (v.uniqueID:lower() == class:lower() or nut.util.stringMatches(L(v.name, client), class))) then
-							class = v.uniqueID
-							info2 = v
-							found = true
-
-							break
-						end
-					end
-
-					if (!found) then
-						return L("invalidClass", client)
-					end
-				else
-					class = ""
-				end
-
-				PLUGIN.spawns[faction] = PLUGIN.spawns[faction] or {}
-				PLUGIN.spawns[faction][class] = PLUGIN.spawns[faction][class] or {}
-
-				table.insert(PLUGIN.spawns[faction][class], client:GetPos())
-
-				PLUGIN:SaveSpawns()
-
-				local name = L(info.name, client)
-
-				if (info2) then
-					name = name.." ("..L(info2.name, client)..")"
-				end
-
-				return L("spawnAdded", client, name)
-			else
-				return L("invalidFaction", client)
-			end
-		else
-			return L("invalidArg", client, 1)
+		if (info2) then
+			class = info2.uniqueID
 		end
+
+		PLUGIN.spawns[faction] = PLUGIN.spawns[faction] or {}
+		PLUGIN.spawns[faction][class] = PLUGIN.spawns[faction][class] or {}
+
+		table.insert(PLUGIN.spawns[faction][class], client:GetPos())
+
+		PLUGIN:SaveSpawns()
+
+		local name = L(info.name, client)
+
+		if (info2) then
+			name = name.." ("..L(info2.name, client)..")"
+		end
+
+		return L("spawnAdded", client, name)
 	end
 })
 
 nut.command.add("spawnremove", {
 	adminOnly = true,
-	syntax = "[number radius]",
-	onRun = function(client, arguments)
+	arguments = nut.type.tor(nut.type.number, nut.type.optional),
+	onRun = function(client, radius)
 		local position = client:GetPos()
-		local radius = tonumber(arguments[1]) or 120
+		radius = radius or 120
 		local i = 0
 
 		for k, v in pairs(PLUGIN.spawns) do

--- a/plugins/storage/sh_plugin.lua
+++ b/plugins/storage/sh_plugin.lua
@@ -30,15 +30,13 @@ end
 
 nut.command.add("storagelock", {
 	adminOnly = true,
-	syntax = "[string password]",
-	onRun = function(client, arguments)
+	arguments = nut.type.tor(nut.type.string, nut.type.optional),
+	onRun = function(client, password)
 		local trace = client:GetEyeTraceNoCursor()
 		local ent = trace.Entity
 
 		if (ent and ent:IsValid()) then
-			local password = table.concat(arguments, " ")
-
-			if (password ~= "") then
+			if (password and password ~= "") then
 				ent:setNetVar("locked", true)
 				ent.password = password
 				client:notifyLocalized("storPass", password)


### PR DESCRIPTION
First steps to a command arguments overhaul, this will be an active draft PR. Just getting it started for now.
The goals of this are mainly to make it simpler to create commands/arguments and know what to expect in the onRun function, it should automatically check the input arguments when running the command to see if they match the commands arguments list and replace any input arguments if needed (see how nut.type.player returns a findPlayer call and if it's successful it gets sent on to the onRun)

The basics seem to work as of right now (replaced /roll and /pm to test optional and required arguments) but I still think we could setup a new system that automatically generates more scoped/specific net.* messages for every command.
Probably should also come up with a way to make any nut.type.string argument that is final in the command's argument list not require quotes surrounding it.

This also implements a basic "type" library, could be expanded upon and/or used elsewhere in the framework.

Until this is in a better spot I think getting CAMI in should be looked at first, and also any temporary fixes that may be needed first until we finish this up.